### PR TITLE
Improve login security and plan browsing experience

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
     "PyQt5",
     "requests",
+    "cryptography",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ PySocks==1.7.1
 python-dotenv==1.0.0
 PyYAML==6.0.1
 requests
+cryptography
 Flask
 mysql-connector-python==8.0.26
 PyJWT==2.1.0

--- a/tts_client/app.py
+++ b/tts_client/app.py
@@ -7,8 +7,9 @@ import sys
 from PyQt5 import QtWidgets
 
 from .core.api_client import ApiClient
-from .core.auth import AuthStore, RememberMePayload
+from .core.auth import AuthStore, RememberedCredentials
 from .core.exceptions import AuthenticationError, ClientError, NetworkError
+from .core.logging import configure_logging
 from .core.ota import OTAUpdater
 from .core.settings import WindowStateStore
 from .monitoring.manager import MonitoringManager
@@ -21,7 +22,8 @@ logger = logging.getLogger(__name__)
 def main() -> int:
     """Run the Qt event loop."""
 
-    logging.basicConfig(level=logging.INFO, format="[%(asctime)s] %(levelname)s - %(message)s")
+    log_dir = configure_logging()
+    logger.info("应用启动，日志目录: %s", log_dir)
 
     app = QtWidgets.QApplication(sys.argv)
     api_client = ApiClient()
@@ -33,8 +35,7 @@ def main() -> int:
     login_dialog = LoginDialog()
     remembered = auth_store.load()
     if remembered:
-        login_dialog.set_initial_values(remembered.username, True)
-        api_client.set_token(remembered.token)
+        login_dialog.set_initial_values(remembered.username, remembered.password, True)
 
     user_info: dict[str, object] = {}
 
@@ -44,16 +45,18 @@ def main() -> int:
             data = api_client.authenticate(username, password)
         except AuthenticationError as exc:
             login_dialog.set_error(str(exc))
+            logger.warning("用户 %s 登录失败（认证）: %s", username, exc)
             return
         except (ClientError, NetworkError) as exc:
             login_dialog.set_error(str(exc))
+            logger.error("用户 %s 登录失败（网络/客户端）: %s", username, exc)
             return
         user_info = data.get("user", {}) if isinstance(data, dict) else {}
-        token = data.get("token")
-        if remember and token:
-            auth_store.save(RememberMePayload(username=username, token=token))
+        if remember:
+            auth_store.save(RememberedCredentials(username=username, password=password))
         else:
             auth_store.clear()
+        logger.info("用户 %s 登录成功", username)
         login_dialog.accept()
 
     login_dialog.login_requested.connect(handle_login)

--- a/tts_client/core/api_client.py
+++ b/tts_client/core/api_client.py
@@ -10,7 +10,7 @@ import requests
 
 from .config import SETTINGS
 from .exceptions import AuthenticationError, ClientError, NetworkError
-from .models import Department, PlanCase, Project, TestPlan
+from .models import Department, PlanCase, PlanDetail, Project, TestPlan
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,10 @@ class ApiClient:
             },
         )
         return [TestPlan.from_dict(item) for item in payload.get("data", {}).get("items", [])]
+
+    def get_plan_detail(self, plan_id: int) -> PlanDetail:
+        payload = self._request("GET", f"/test-plans/{plan_id}")
+        return PlanDetail.from_dict(payload.get("data", {}))
 
     def get_plan_cases(self, plan_id: int) -> List[PlanCase]:
         payload = self._request("GET", f"/test-plans/{plan_id}/cases")

--- a/tts_client/core/auth.py
+++ b/tts_client/core/auth.py
@@ -5,26 +5,41 @@ from dataclasses import dataclass
 from typing import Optional
 
 from .config import SETTINGS
+from .security import decrypt_password, encrypt_password
 from .storage import load_json, save_json
 
 
 @dataclass(slots=True)
 class RememberMePayload:
-    """Represents saved credentials for automatic login."""
+    """Serialized payload persisted to disk."""
 
     username: str
-    token: str
+    password_cipher: str
 
     @classmethod
     def from_dict(cls, payload: dict[str, str]) -> "RememberMePayload":
         username = payload.get("username")
-        token = payload.get("token")
-        if not username or not token:
-            raise ValueError("missing username/token")
-        return cls(username=username, token=token)
+        cipher = payload.get("password") or payload.get("password_cipher")
+        if not username or not cipher:
+            raise ValueError("missing username/password")
+        return cls(username=username, password_cipher=cipher)
 
     def to_dict(self) -> dict[str, str]:
-        return {"username": self.username, "token": self.token}
+        return {"username": self.username, "password": self.password_cipher}
+
+    def decrypt(self) -> "RememberedCredentials":
+        password = decrypt_password(self.password_cipher)
+        if password is None:
+            raise ValueError("无法解密存储的密码")
+        return RememberedCredentials(username=self.username, password=password)
+
+
+@dataclass(slots=True)
+class RememberedCredentials:
+    """Plain-text credentials returned to the caller."""
+
+    username: str
+    password: str
 
 
 class AuthStore:
@@ -33,16 +48,20 @@ class AuthStore:
     def __init__(self) -> None:
         self._path = SETTINGS.remember_me_file
 
-    def load(self) -> Optional[RememberMePayload]:
+    def load(self) -> Optional[RememberedCredentials]:
         payload = load_json(self._path)
         if not payload:
             return None
         try:
-            return RememberMePayload.from_dict(payload)
+            stored = RememberMePayload.from_dict(payload)
+            return stored.decrypt()
         except ValueError:
+            self.clear()
             return None
 
-    def save(self, payload: RememberMePayload) -> None:
+    def save(self, credentials: RememberedCredentials) -> None:
+        cipher = encrypt_password(credentials.password)
+        payload = RememberMePayload(username=credentials.username, password_cipher=cipher)
         save_json(self._path, payload.to_dict())
 
     def clear(self) -> None:

--- a/tts_client/core/config.py
+++ b/tts_client/core/config.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from .paths import get_patvs_root
+
 
 APP_NAME = "Test Tracking System"
 CONFIG_DIR = Path.home() / ".tts_client"
 CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+PATVS_ROOT = get_patvs_root()
 
 
 @dataclass(slots=True)
@@ -35,9 +38,10 @@ class ClientSettings:
 
     api: ApiSettings = ApiSettings()
     ota: OTASettings = OTASettings()
-    remember_me_file: Path = CONFIG_DIR / "remember_me.json"
+    remember_me_file: Path = PATVS_ROOT / "credentials.json"
     window_state_file: Path = CONFIG_DIR / "window_state.json"
     monitoring_cache_file: Path = CONFIG_DIR / "monitoring_state.json"
+    log_root: Path = PATVS_ROOT
 
 
 SETTINGS = ClientSettings()

--- a/tts_client/core/logging.py
+++ b/tts_client/core/logging.py
@@ -1,0 +1,58 @@
+"""Application-wide logging utilities."""
+from __future__ import annotations
+
+import datetime as dt
+import logging
+import sys
+import traceback
+from pathlib import Path
+
+from .config import SETTINGS
+
+
+def configure_logging() -> Path:
+    """Configure root logging handlers and return the active log directory."""
+
+    log_root = SETTINGS.log_root
+    log_dir = log_root / dt.datetime.now().strftime("%Y%m%d")
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    log_file = log_dir / "application.log"
+
+    formatter = logging.Formatter("[%(asctime)s] %(levelname)s - %(name)s - %(message)s")
+
+    console = logging.StreamHandler()
+    console.setFormatter(formatter)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    for handler in list(root_logger.handlers):
+        root_logger.removeHandler(handler)
+        handler.close()
+
+    root_logger.setLevel(logging.INFO)
+    root_logger.addHandler(console)
+    root_logger.addHandler(file_handler)
+
+    install_exception_hook(log_dir / "crash.log")
+    return log_dir
+
+
+def install_exception_hook(crash_file: Path) -> None:
+    """Ensure uncaught exceptions are persisted to *crash_file*."""
+
+    def handle_exception(exc_type, exc_value, exc_traceback):  # type: ignore[override]
+        if issubclass(exc_type, KeyboardInterrupt):
+            sys.__excepthook__(exc_type, exc_value, exc_traceback)
+            return
+
+        message = "".join(traceback.format_exception(exc_type, exc_value, exc_traceback))
+        logging.critical("应用发生未处理异常:\n%s", message)
+        crash_file.parent.mkdir(parents=True, exist_ok=True)
+        with crash_file.open("a", encoding="utf-8") as handle:
+            handle.write(f"[{dt.datetime.now().isoformat()}] {message}\n")
+
+    sys.excepthook = handle_exception  # type: ignore[assignment]
+

--- a/tts_client/core/models.py
+++ b/tts_client/core/models.py
@@ -87,6 +87,139 @@ class TestPlan:
 
 
 @dataclass(slots=True)
+class PlanStatistics:
+    """Aggregated execution statistics for a test plan."""
+
+    total_results: int
+    executed_results: int
+    passed: int
+    failed: int
+    blocked: int
+    skipped: int
+    not_run: int
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "PlanStatistics":
+        return cls(
+            total_results=payload.get("total_results", 0),
+            executed_results=payload.get("executed_results", 0),
+            passed=payload.get("passed", 0),
+            failed=payload.get("failed", 0),
+            blocked=payload.get("blocked", 0),
+            skipped=payload.get("skipped", 0),
+            not_run=payload.get("not_run", 0),
+        )
+
+
+@dataclass(slots=True)
+class PlanTester:
+    """Tester assigned to a plan."""
+
+    id: int
+    name: str
+    username: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "PlanTester":
+        tester_info = payload.get("tester") or {}
+        return cls(
+            id=payload.get("user_id")
+            or tester_info.get("id")
+            or payload.get("id")
+            or 0,
+            name=payload.get("name") or tester_info.get("username", ""),
+            username=tester_info.get("username"),
+        )
+
+    def display_name(self) -> str:
+        return self.name or (self.username or "")
+
+
+@dataclass(slots=True)
+class PlanExecutionRun:
+    """Execution summary for a single run of a plan."""
+
+    id: int
+    name: str
+    status: Optional[str]
+    run_type: Optional[str]
+    total: int
+    executed: int
+    passed: int
+    failed: int
+    blocked: int
+    skipped: int
+    not_run: int
+    start_time: Optional[str]
+    end_time: Optional[str]
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "PlanExecutionRun":
+        return cls(
+            id=payload.get("id"),
+            name=payload.get("name", ""),
+            status=payload.get("status"),
+            run_type=payload.get("run_type"),
+            total=payload.get("total", 0),
+            executed=payload.get("executed", 0),
+            passed=payload.get("passed", 0),
+            failed=payload.get("failed", 0),
+            blocked=payload.get("blocked", 0),
+            skipped=payload.get("skipped", 0),
+            not_run=payload.get("not_run", 0),
+            start_time=payload.get("start_time"),
+            end_time=payload.get("end_time"),
+        )
+
+
+@dataclass(slots=True)
+class PlanDetail:
+    """Detailed information for a selected test plan."""
+
+    id: int
+    name: str
+    description: Optional[str]
+    department_name: Optional[str]
+    project_name: Optional[str]
+    start_date: Optional[str]
+    end_date: Optional[str]
+    status: Optional[str]
+    testers: List[PlanTester] = field(default_factory=list)
+    device_models: List[DeviceModel] = field(default_factory=list)
+    statistics: Optional[PlanStatistics] = None
+    execution_runs: List[PlanExecutionRun] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "PlanDetail":
+        return cls(
+            id=payload.get("id"),
+            name=payload.get("name", ""),
+            description=payload.get("description"),
+            department_name=payload.get("department_name"),
+            project_name=payload.get("project_name"),
+            start_date=payload.get("start_date"),
+            end_date=payload.get("end_date"),
+            status=payload.get("status"),
+            testers=[PlanTester.from_dict(item) for item in payload.get("testers", [])],
+            device_models=[DeviceModel.from_dict(item) for item in payload.get("device_models", [])],
+            statistics=PlanStatistics.from_dict(payload.get("statistics", {}))
+            if payload.get("statistics")
+            else None,
+            execution_runs=[
+                PlanExecutionRun.from_dict(item) for item in payload.get("execution_runs", [])
+            ],
+        )
+
+    def tester_names(self) -> List[str]:
+        names: List[str] = []
+        for tester in self.testers:
+            name = tester.display_name()
+            if name:
+                names.append(name)
+        return names
+
+
+@dataclass(slots=True)
 class CaseExecutionResult:
     """Represents a single execution run for a plan case."""
 

--- a/tts_client/core/paths.py
+++ b/tts_client/core/paths.py
@@ -1,0 +1,16 @@
+"""Shared filesystem helpers for PATVS specific storage locations."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def get_patvs_root() -> Path:
+    """Return the base directory for PATVS assets, creating it if missing."""
+
+    default = Path("C:/PATVS") if os.name == "nt" else Path.home() / "PATVS"
+    root_env = os.environ.get("PATVS_ROOT", str(default))
+    root = Path(root_env)
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+

--- a/tts_client/core/security.py
+++ b/tts_client/core/security.py
@@ -1,0 +1,43 @@
+"""Lightweight encryption helpers for sensitive credentials."""
+from __future__ import annotations
+
+import base64
+import getpass
+import hashlib
+import platform
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+def _derive_key() -> bytes:
+    """Derive a stable key bound to the current machine and user."""
+
+    user = getpass.getuser()
+    node = platform.node()
+    fingerprint = f"{user}:{node}".encode("utf-8")
+    digest = hashlib.sha256(fingerprint).digest()
+    return base64.urlsafe_b64encode(digest)
+
+
+def encrypt_password(password: str) -> str:
+    """Return an encrypted representation of *password*."""
+
+    if not password:
+        raise ValueError("password must not be empty")
+    cipher = Fernet(_derive_key())
+    token = cipher.encrypt(password.encode("utf-8"))
+    return token.decode("ascii")
+
+
+def decrypt_password(token: str) -> Optional[str]:
+    """Return the decrypted password stored in *token* if possible."""
+
+    if not token:
+        return None
+    cipher = Fernet(_derive_key())
+    try:
+        return cipher.decrypt(token.encode("ascii")).decode("utf-8")
+    except (InvalidToken, ValueError):
+        return None
+

--- a/tts_client/ui/login_dialog.py
+++ b/tts_client/ui/login_dialog.py
@@ -20,10 +20,12 @@ class LoginDialog(QtWidgets.QDialog):
 
     # ------------------------------------------------------------------
     def _build_ui(self) -> None:
-        palette = self.palette()
-        palette.setColor(QtGui.QPalette.Window, QtGui.QColor("#141a26"))
-        palette.setColor(QtGui.QPalette.WindowText, QtGui.QColor("#f7f9fc"))
-        self.setPalette(palette)
+        self.setStyleSheet(
+            "QDialog {"
+            "  background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #0f172a, stop:1 #1e293b);"
+            "  color: #f7f9fc;"
+            "}"
+        )
 
         main_layout = QtWidgets.QVBoxLayout(self)
         main_layout.setContentsMargins(32, 32, 32, 32)
@@ -44,9 +46,10 @@ class LoginDialog(QtWidgets.QDialog):
         form_widget.setObjectName("form_panel")
         form_widget.setStyleSheet(
             "#form_panel {"
-            "  background: #1f2937;"
-            "  border-radius: 16px;"
-            "  padding: 28px;"
+            "  background: rgba(17, 25, 40, 0.82);"
+            "  border: 1px solid rgba(148, 163, 184, 0.18);"
+            "  border-radius: 18px;"
+            "  padding: 32px;"
             "  color: #f7f9fc;"
             "}"
         )
@@ -104,8 +107,9 @@ class LoginDialog(QtWidgets.QDialog):
         self._password.returnPressed.connect(self._on_login_clicked)
 
     # ------------------------------------------------------------------
-    def set_initial_values(self, username: str, remember: bool) -> None:
+    def set_initial_values(self, username: str, password: str = "", remember: bool = True) -> None:
         self._username.setText(username)
+        self._password.setText(password)
         self._remember.setChecked(remember)
 
     def set_error(self, message: str) -> None:

--- a/tts_client/ui/main_window.py
+++ b/tts_client/ui/main_window.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import logging
 import os
 from typing import Dict, List, Optional
 
@@ -9,7 +10,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 
 from ..core.api_client import ApiClient, encode_attachment
 from ..core.exceptions import AuthenticationError, ClientError, ValidationError
-from ..core.models import Department, PlanCase, Project, TestPlan
+from ..core.models import Department, PlanCase, PlanDetail, Project, TestPlan
 from ..core.monitor_parser import MonitoringAction, parse_keywords, require_attachment
 from ..core.settings import WindowStateStore
 from ..monitoring.manager import MonitoringManager
@@ -30,6 +31,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._monitoring = monitoring
         self._state_store = state_store
         self._user = user_info
+        self._logger = logging.getLogger(__name__)
 
         self._departments: List[Department] = []
         self._projects: List[Project] = []
@@ -39,6 +41,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._current_case: Optional[PlanCase] = None
         self._current_actions: List[MonitoringAction] = []
         self._attachments: List[Dict[str, str]] = []
+        self._plan_detail: Optional[PlanDetail] = None
 
         self.setWindowTitle("TTS 测试执行客户端")
         self.resize(1280, 720)
@@ -82,39 +85,62 @@ class MainWindow(QtWidgets.QMainWindow):
 
         filter_box = QtWidgets.QGroupBox("筛选")
         filter_layout = QtWidgets.QGridLayout(filter_box)
+        filter_layout.setHorizontalSpacing(12)
         filter_layout.addWidget(QtWidgets.QLabel("目录"), 0, 0)
-        self._directory_filter = QtWidgets.QLineEdit()
+        self._directory_filter = QtWidgets.QComboBox()
+        self._directory_filter.addItem("全部", None)
         filter_layout.addWidget(self._directory_filter, 0, 1)
 
         filter_layout.addWidget(QtWidgets.QLabel("机型"), 0, 2)
         self._device_filter = QtWidgets.QComboBox()
-        self._device_filter.addItem("全部")
+        self._device_filter.addItem("全部", None)
         filter_layout.addWidget(self._device_filter, 0, 3)
 
-        filter_layout.addWidget(QtWidgets.QLabel("优先级"), 1, 0)
-        self._priority_filter = QtWidgets.QComboBox()
-        self._priority_filter.addItems(["全部", "P0", "P1", "P2", "P3"])
-        filter_layout.addWidget(self._priority_filter, 1, 1)
-
-        filter_layout.addWidget(QtWidgets.QLabel("结果"), 1, 2)
+        filter_layout.addWidget(QtWidgets.QLabel("结果"), 1, 0)
         self._result_filter = QtWidgets.QComboBox()
-        self._result_filter.addItems(["全部", "pass", "fail", "blocked", "pending"])
-        filter_layout.addWidget(self._result_filter, 1, 3)
+        self._result_filter.addItem("全部", None)
+        for value in ["pass", "fail", "blocked", "pending", "skipped"]:
+            self._result_filter.addItem(value, value)
+        filter_layout.addWidget(self._result_filter, 1, 1, 1, 3)
+        filter_layout.setColumnStretch(1, 1)
+        filter_layout.setColumnStretch(3, 1)
 
         left_panel.addWidget(filter_box)
 
-        self._case_table = QtWidgets.QTableWidget(0, 5)
-        self._case_table.setHorizontalHeaderLabels(["ID", "标题", "优先级", "目录", "最新结果"])
-        self._case_table.horizontalHeader().setStretchLastSection(True)
-        self._case_table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
-        self._case_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
-        left_panel.addWidget(self._case_table, stretch=1)
+        self._case_tree = QtWidgets.QTreeWidget()
+        self._case_tree.setHeaderLabels(["用例标题"])
+        self._case_tree.header().setStretchLastSection(True)
+        self._case_tree.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self._case_tree.setIndentation(18)
+        self._case_tree.setUniformRowHeights(True)
+        left_panel.addWidget(self._case_tree, stretch=1)
 
         root_layout.addLayout(left_panel, stretch=3)
 
         # Right: detail and monitoring panel
         detail_panel = QtWidgets.QVBoxLayout()
         detail_panel.setSpacing(10)
+
+        plan_box = QtWidgets.QGroupBox("计划概览")
+        plan_layout = QtWidgets.QGridLayout(plan_box)
+        plan_layout.setVerticalSpacing(6)
+        plan_layout.addWidget(QtWidgets.QLabel("状态"), 0, 0)
+        self._plan_status_label = QtWidgets.QLabel("-")
+        plan_layout.addWidget(self._plan_status_label, 0, 1)
+        plan_layout.addWidget(QtWidgets.QLabel("时间周期"), 1, 0)
+        self._plan_period_label = QtWidgets.QLabel("-")
+        self._plan_period_label.setWordWrap(True)
+        plan_layout.addWidget(self._plan_period_label, 1, 1)
+        plan_layout.addWidget(QtWidgets.QLabel("测试人员"), 2, 0)
+        self._plan_tester_label = QtWidgets.QLabel("-")
+        self._plan_tester_label.setWordWrap(True)
+        plan_layout.addWidget(self._plan_tester_label, 2, 1)
+        plan_layout.addWidget(QtWidgets.QLabel("执行统计"), 3, 0)
+        self._plan_stats_label = QtWidgets.QLabel("-")
+        self._plan_stats_label.setWordWrap(True)
+        plan_layout.addWidget(self._plan_stats_label, 3, 1)
+        plan_layout.setColumnStretch(1, 1)
+        detail_panel.addWidget(plan_box)
 
         self._title_label = QtWidgets.QLabel("请选择一条用例")
         self._title_label.setStyleSheet("font-size: 18px; font-weight: 600;")
@@ -214,11 +240,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self._department_combo.currentIndexChanged.connect(self._on_department_changed)
         self._project_combo.currentIndexChanged.connect(self._on_project_changed)
         self._plan_combo.currentIndexChanged.connect(self._on_plan_changed)
-        self._directory_filter.textChanged.connect(self._apply_filters)
+        self._directory_filter.currentIndexChanged.connect(self._apply_filters)
         self._device_filter.currentIndexChanged.connect(self._apply_filters)
-        self._priority_filter.currentIndexChanged.connect(self._apply_filters)
         self._result_filter.currentIndexChanged.connect(self._apply_filters)
-        self._case_table.itemSelectionChanged.connect(self._on_case_selected)
+        self._case_tree.currentItemChanged.connect(self._on_case_selected)
 
         self._start_monitor_btn.clicked.connect(self._start_monitoring)
         self._stop_monitor_btn.clicked.connect(self._stop_monitoring)
@@ -315,67 +340,216 @@ class MainWindow(QtWidgets.QMainWindow):
     def _on_plan_changed(self, index: int) -> None:
         if index < 0 or index >= len(self._plans):
             self._cases = []
-            self._refresh_case_table()
+            self._plan_detail = None
+            self._update_plan_summary()
+            self._refresh_directory_filter()
+            self._refresh_device_filter()
+            self._filtered_cases = []
+            self._refresh_case_tree()
             return
-        plan_id = self._plan_combo.currentData()
+
+        plan = self._plans[index]
+        plan_id = int(self._plan_combo.currentData())
+        self._logger.info("选择计划 %s (ID: %s)", plan.name, plan_id)
+
         try:
-            self._cases = self._api.get_plan_cases(int(plan_id))
+            self._plan_detail = self._api.get_plan_detail(plan_id)
+        except AuthenticationError:
+            QtWidgets.QMessageBox.critical(self, "未授权", "凭据已失效，请重新登录。")
+            self.close()
+            return
+        except ClientError as exc:
+            QtWidgets.QMessageBox.warning(self, "加载计划详情失败", str(exc))
+            self._plan_detail = None
+        self._update_plan_summary()
+
+        try:
+            self._cases = self._api.get_plan_cases(plan_id)
         except ClientError as exc:
             QtWidgets.QMessageBox.warning(self, "加载用例失败", str(exc))
             self._cases = []
+        else:
+            self._logger.info("计划 %s 用例数量: %d", plan.name, len(self._cases))
+
+        self._refresh_directory_filter()
         self._refresh_device_filter()
         self._apply_filters()
 
     def _refresh_device_filter(self) -> None:
-        devices = sorted({model.name for case in self._cases for model in case.device_models if model.name})
+        devices = sorted(
+            {
+                model.name or model.model_code or str(model.id)
+                for case in self._cases
+                for model in case.device_models
+                if model.name or model.model_code
+            }
+        )
         self._device_filter.blockSignals(True)
         self._device_filter.clear()
-        self._device_filter.addItem("全部")
+        self._device_filter.addItem("全部", None)
         for name in devices:
-            self._device_filter.addItem(name)
+            self._device_filter.addItem(name, name)
         self._device_filter.blockSignals(False)
+        self._device_filter.setCurrentIndex(0)
+
+    def _refresh_directory_filter(self) -> None:
+        directories: List[str] = []
+        seen: set[str] = set()
+        for case in self._cases:
+            directory = self._normalize_directory(case.group_path)
+            if directory not in seen:
+                seen.add(directory)
+                directories.append(directory)
+        directories.sort()
+        self._directory_filter.blockSignals(True)
+        self._directory_filter.clear()
+        self._directory_filter.addItem("全部", None)
+        for directory in directories:
+            self._directory_filter.addItem(directory, directory)
+        self._directory_filter.blockSignals(False)
+        self._directory_filter.setCurrentIndex(0)
 
     def _apply_filters(self) -> None:
-        directory_term = self._directory_filter.text().strip().lower()
-        device_name = self._device_filter.currentText()
-        priority = self._priority_filter.currentText()
-        result = self._result_filter.currentText()
+        directory_value = self._directory_filter.currentData()
+        device_value = self._device_filter.currentData()
+        result_value = self._result_filter.currentData()
 
         def matches(case: PlanCase) -> bool:
-            if directory_term and directory_term not in (case.group_path or "").lower():
+            if directory_value and self._normalize_directory(case.group_path) != directory_value:
                 return False
-            if device_name != "全部":
-                names = {model.name for model in case.device_models}
-                if device_name not in names:
+            if device_value:
+                names = {
+                    model.name or model.model_code or str(model.id)
+                    for model in case.device_models
+                    if model.name or model.model_code or model.id
+                }
+                if device_value not in names:
                     return False
-            if priority != "全部" and (case.priority or "").lower() != priority.lower():
-                return False
-            if result != "全部" and (case.latest_result or "pending") != result:
-                return False
+            if result_value:
+                latest = (case.latest_result or "pending").lower()
+                if latest != result_value:
+                    return False
             return True
 
         self._filtered_cases = [case for case in self._cases if matches(case)]
-        self._refresh_case_table()
+        self._logger.info("筛选后用例数量: %d", len(self._filtered_cases))
+        self._refresh_case_tree()
 
-    def _refresh_case_table(self) -> None:
-        self._case_table.setRowCount(len(self._filtered_cases))
-        for row, case in enumerate(self._filtered_cases):
-            self._case_table.setItem(row, 0, QtWidgets.QTableWidgetItem(str(case.case_id)))
-            self._case_table.setItem(row, 1, QtWidgets.QTableWidgetItem(case.title))
-            self._case_table.setItem(row, 2, QtWidgets.QTableWidgetItem(case.priority or "-"))
-            self._case_table.setItem(row, 3, QtWidgets.QTableWidgetItem(case.group_path or "-"))
-            self._case_table.setItem(row, 4, QtWidgets.QTableWidgetItem(case.latest_result or "pending"))
-        if self._filtered_cases:
-            self._case_table.selectRow(0)
+    def _update_plan_summary(self) -> None:
+        detail = self._plan_detail
+        if not detail:
+            self._plan_status_label.setText("-")
+            self._plan_period_label.setText("-")
+            self._plan_tester_label.setText("-")
+            self._plan_stats_label.setText("-")
+            return
+
+        if detail.start_date and detail.end_date:
+            period = f"{detail.start_date} ~ {detail.end_date}"
+        elif detail.start_date:
+            period = f"自 {detail.start_date}"
+        elif detail.end_date:
+            period = f"截至 {detail.end_date}"
+        else:
+            period = "-"
+
+        testers = "、".join(detail.tester_names()) or "未分配"
+        if detail.statistics:
+            stats = detail.statistics
+            stats_parts = [
+                f"总数 {stats.total_results}",
+                f"已执行 {stats.executed_results}",
+                f"通过 {stats.passed}",
+                f"失败 {stats.failed}",
+                f"阻塞 {stats.blocked}",
+                f"未执行 {stats.not_run}",
+            ]
+            if stats.skipped:
+                stats_parts.append(f"跳过 {stats.skipped}")
+            stats_text = " · ".join(stats_parts)
+        else:
+            stats_text = "暂无统计数据"
+
+        self._plan_status_label.setText(detail.status or "-")
+        self._plan_period_label.setText(period)
+        self._plan_tester_label.setText(testers)
+        self._plan_stats_label.setText(stats_text)
+
+    def _refresh_case_tree(self) -> None:
+        self._case_tree.blockSignals(True)
+        self._case_tree.clear()
+        if not self._filtered_cases:
+            self._case_tree.blockSignals(False)
+            self._update_case_detail(None)
+            return
+
+        parents: dict[tuple[str, ...], QtWidgets.QTreeWidgetItem] = {}
+        root = self._case_tree.invisibleRootItem()
+
+        for case in self._filtered_cases:
+            tokens = self._directory_tokens(case.group_path)
+            parent = root
+            key: tuple[str, ...] = ()
+            for token in tokens:
+                key = key + (token,)
+                if key not in parents:
+                    node = QtWidgets.QTreeWidgetItem([token])
+                    node.setFlags(QtCore.Qt.ItemIsEnabled)
+                    parent.addChild(node)
+                    parents[key] = node
+                parent = parents[key]
+            item = QtWidgets.QTreeWidgetItem([case.title])
+            item.setData(0, QtCore.Qt.UserRole, case)
+            parent.addChild(item)
+
+        self._case_tree.expandAll()
+        self._case_tree.blockSignals(False)
+        self._select_first_case()
+
+    def _select_first_case(self) -> None:
+        root = self._case_tree.invisibleRootItem()
+
+        def find_case(node: QtWidgets.QTreeWidgetItem) -> Optional[QtWidgets.QTreeWidgetItem]:
+            for index in range(node.childCount()):
+                child = node.child(index)
+                if child.data(0, QtCore.Qt.UserRole):
+                    return child
+                found = find_case(child)
+                if found:
+                    return found
+            return None
+
+        first_case = find_case(root)
+        if first_case is not None:
+            self._case_tree.setCurrentItem(first_case)
         else:
             self._update_case_detail(None)
 
-    def _on_case_selected(self) -> None:
-        selected = self._case_table.currentRow()
-        if selected < 0 or selected >= len(self._filtered_cases):
-            self._update_case_detail(None)
+    def _normalize_directory(self, path: Optional[str]) -> str:
+        if not path:
+            return "未分组"
+        parts = [part.strip() for part in str(path).split("/") if part and part.lower() != "root"]
+        return "/".join(parts) if parts else "未分组"
+
+    def _directory_tokens(self, path: Optional[str]) -> List[str]:
+        normalized = self._normalize_directory(path)
+        if normalized == "未分组":
+            return ["未分组"]
+        return normalized.split("/")
+
+    def _on_case_selected(
+        self,
+        current: Optional[QtWidgets.QTreeWidgetItem],
+        previous: Optional[QtWidgets.QTreeWidgetItem],
+    ) -> None:
+        case = current.data(0, QtCore.Qt.UserRole) if current else None
+        if not case:
+            if previous and previous.data(0, QtCore.Qt.UserRole):
+                self._case_tree.setCurrentItem(previous)
+            else:
+                self._update_case_detail(None)
             return
-        case = self._filtered_cases[selected]
+        self._logger.info("选中用例: %s (ID: %s)", case.title, case.case_id)
         self._update_case_detail(case)
 
     def _update_case_detail(self, case: Optional[PlanCase]) -> None:
@@ -396,7 +570,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._title_label.setText(case.title)
         self._priority_label.setText(case.priority or "-")
         self._result_label.setText(case.latest_result or "pending")
-        self._directory_label.setText(case.group_path or "-")
+        self._directory_label.setText(self._normalize_directory(case.group_path))
         self._device_combo.clear()
         self._device_combo.addItem("(未指定)", userData=None)
         for model in case.device_models:
@@ -434,12 +608,15 @@ class MainWindow(QtWidgets.QMainWindow):
         start_time = dt.datetime.now().isoformat()
         self._monitoring.start(self._current_case.case_id, self._current_actions, start_time)
         self._append_log("监控已启动")
+        self._logger.info("已启动监控: 用例 %s", self._current_case.case_id)
         self._start_monitor_btn.setEnabled(False)
         self._stop_monitor_btn.setEnabled(True)
 
     def _stop_monitoring(self) -> None:
         self._monitoring.stop()
         self._append_log("监控停止请求已发送")
+        if self._current_case:
+            self._logger.info("已请求停止监控: 用例 %s", self._current_case.case_id)
         self._start_monitor_btn.setEnabled(True)
         self._stop_monitor_btn.setEnabled(False)
 
@@ -506,6 +683,12 @@ class MainWindow(QtWidgets.QMainWindow):
         except ClientError as exc:
             QtWidgets.QMessageBox.warning(self, "提交失败", str(exc))
             return
+        self._logger.info(
+            "提交结果: 用例 %s (结果=%s, 设备=%s)",
+            self._current_case.case_id,
+            result,
+            device_model_id,
+        )
         QtWidgets.QMessageBox.information(self, "成功", "结果已提交")
         self._remark_edit.clear()
         self._failure_edit.clear()


### PR DESCRIPTION
## Summary
- store remember-me credentials in an encrypted file under C:/PATVS and configure logging to write application and crash logs into dated PATVS folders
- add support for loading detailed plan metadata and surface plan period, testers, and statistics in the UI with a tree-based case browser and simplified filters
- refresh the login dialog styling with a new gradient background and remember-me password prefill while adding a cryptography dependency

## Testing
- python -m compileall tts_client

------
https://chatgpt.com/codex/tasks/task_b_68f87f3046048320b1ffdd821591471e