### PR TITLE
Revamp execution UI for device-driven workflow

### DIFF
--- a/api/client.py
+++ b/api/client.py
@@ -13,6 +13,8 @@ from ..models import (
     ExecutionPayload,
     Plan,
     PlanCase,
+    PlanCaseStep,
+    PlanDeviceModel,
     Project,
 )
 
@@ -78,6 +80,39 @@ class ApiClient:
             plans.append(Plan(**item))
         return plans
 
+    def get_plan_device_models(self, plan_id: int) -> List[PlanDeviceModel]:
+        payload = self._get(f"/test-plans/{plan_id}")
+        data = payload.get("data", {})
+        models: List[PlanDeviceModel] = []
+        for item in data.get("device_models", []) or []:
+            device_info = item.get("device_model") or {}
+            name = (
+                item.get("name")
+                or device_info.get("name")
+                or item.get("device_model_name")
+                or ""
+            )
+            models.append(
+                PlanDeviceModel(
+                    plan_device_model_id=
+                        item.get("id")
+                        or item.get("plan_device_model_id")
+                        or device_info.get("plan_device_model_id"),
+                    device_model_id=
+                        item.get("device_model_id") or device_info.get("id"),
+                    name=name,
+                    model_code=
+                        item.get("model_code")
+                        or device_info.get("model_code")
+                        or item.get("device_model_code"),
+                    category=
+                        item.get("category")
+                        or device_info.get("category")
+                        or item.get("device_model_category"),
+                )
+            )
+        return models
+
     def get_plan_cases(
         self,
         plan_id: int,
@@ -99,6 +134,19 @@ class ApiClient:
         cases: List[PlanCase] = []
         for item in payload["data"]["cases"]:
             item.setdefault("execution_results", [])
+            steps_payload = item.get("steps") or []
+            steps: List[PlanCaseStep] = []
+            for step in steps_payload:
+                steps.append(
+                    PlanCaseStep(
+                        no=step.get("no", len(steps) + 1),
+                        action=step.get("action", ""),
+                        expected=step.get("expected", ""),
+                        note=step.get("note", ""),
+                        keyword=step.get("keyword", ""),
+                    )
+                )
+            item["steps"] = steps
             cases.append(PlanCase(**item))
         return cases
 

--- a/models.py
+++ b/models.py
@@ -90,6 +90,15 @@ class PlanCase:
 
 
 @dataclass
+class PlanDeviceModel:
+    plan_device_model_id: Optional[int]
+    device_model_id: Optional[int]
+    name: str
+    model_code: Optional[str] = None
+    category: Optional[str] = None
+
+
+@dataclass
 class ExecutionAttachment:
     file_name: str
     content: str

--- a/ui/execution_result_dialog.py
+++ b/ui/execution_result_dialog.py
@@ -1,0 +1,185 @@
+"""Dialog used to capture execution results for a plan case."""
+from __future__ import annotations
+
+import base64
+import os
+from typing import List, Optional
+
+from PyQt5 import QtCore, QtWidgets
+
+from ..models import ExecutionAttachment, ExecutionPayload, PlanCase
+from ..utils.encryption import encode_timestamp
+
+
+class ExecutionResultDialog(QtWidgets.QDialog):
+    """Modal dialog for recording the execution result of a test case."""
+
+    def __init__(
+        self,
+        case: PlanCase,
+        result: str,
+        requires_attachment: bool,
+        parent: Optional[QtWidgets.QWidget] = None,
+    ) -> None:
+        super().__init__(parent)
+        self.case = case
+        self.result = result
+        self.requires_attachment = requires_attachment
+        self.pending_attachments: List[ExecutionAttachment] = []
+
+        self.setWindowTitle(f"记录结果 - {case.title}")
+        self.resize(520, 560)
+
+        self._build_ui()
+        self._connect_signals()
+
+    # ------------------------------------------------------------------
+    def _build_ui(self) -> None:
+        layout = QtWidgets.QVBoxLayout(self)
+
+        header = QtWidgets.QLabel(f"用例: {self.case.title}")
+        header.setWordWrap(True)
+        header.setStyleSheet("font-weight: 600;")
+        layout.addWidget(header)
+
+        result_label = QtWidgets.QLabel(f"结果: {self._display_result()}")
+        layout.addWidget(result_label)
+
+        layout.addWidget(QtWidgets.QLabel("备注 (必填)"))
+        self.remark_edit = QtWidgets.QPlainTextEdit()
+        self.remark_edit.setPlaceholderText("请输入执行备注")
+        layout.addWidget(self.remark_edit)
+
+        layout.addWidget(QtWidgets.QLabel("失败 / 阻塞原因"))
+        self.failure_reason_edit = QtWidgets.QPlainTextEdit()
+        self.failure_reason_edit.setPlaceholderText("可选填写失败或阻塞原因")
+        self.failure_reason_edit.setMaximumHeight(80)
+        layout.addWidget(self.failure_reason_edit)
+
+        form_grid = QtWidgets.QGridLayout()
+        form_grid.addWidget(QtWidgets.QLabel("缺陷编号"), 0, 0)
+        self.bug_ref_edit = QtWidgets.QLineEdit()
+        self.bug_ref_edit.setPlaceholderText("可选填写关联缺陷编号")
+        form_grid.addWidget(self.bug_ref_edit, 0, 1)
+
+        form_grid.addWidget(QtWidgets.QLabel("开始时间"), 1, 0)
+        self.start_time_edit = QtWidgets.QDateTimeEdit(QtCore.QDateTime.currentDateTime())
+        self.start_time_edit.setCalendarPopup(True)
+        form_grid.addWidget(self.start_time_edit, 1, 1)
+
+        form_grid.addWidget(QtWidgets.QLabel("结束时间"), 2, 0)
+        self.end_time_edit = QtWidgets.QDateTimeEdit(QtCore.QDateTime.currentDateTime())
+        self.end_time_edit.setCalendarPopup(True)
+        form_grid.addWidget(self.end_time_edit, 2, 1)
+
+        layout.addLayout(form_grid)
+
+        attachment_box = QtWidgets.QGroupBox("执行截图")
+        attachment_layout = QtWidgets.QVBoxLayout(attachment_box)
+        self.attachment_list = QtWidgets.QListWidget()
+        attachment_layout.addWidget(self.attachment_list)
+
+        button_row = QtWidgets.QHBoxLayout()
+        self.add_attachment_button = QtWidgets.QPushButton("添加图片")
+        self.clear_attachment_button = QtWidgets.QPushButton("清空")
+        button_row.addWidget(self.add_attachment_button)
+        button_row.addWidget(self.clear_attachment_button)
+        button_row.addStretch()
+        attachment_layout.addLayout(button_row)
+
+        hint_text = (
+            "提示: 该用例关键字包含时间，提交前必须上传图片"
+            if self.requires_attachment and self.result != "blocked"
+            else "可选上传执行截图"
+        )
+        self.attachment_hint = QtWidgets.QLabel(hint_text)
+        if self.requires_attachment and self.result != "blocked":
+            self.attachment_hint.setStyleSheet("color: #d97706;")
+        else:
+            self.attachment_hint.setStyleSheet("color: #6b7280;")
+        attachment_layout.addWidget(self.attachment_hint)
+
+        layout.addWidget(attachment_box)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel
+        )
+        layout.addWidget(self.button_box)
+
+    def _connect_signals(self) -> None:
+        self.add_attachment_button.clicked.connect(self._add_attachment)
+        self.clear_attachment_button.clicked.connect(self._clear_attachments)
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+    # ------------------------------------------------------------------
+    def _display_result(self) -> str:
+        mapping = {"pass": "通过", "fail": "失败", "blocked": "阻塞"}
+        return mapping.get(self.result, self.result)
+
+    def _add_attachment(self) -> None:
+        dialog = QtWidgets.QFileDialog(self, "选择图片")
+        dialog.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
+        dialog.setNameFilters(["图片文件 (*.png *.jpg *.jpeg *.bmp)"])
+        if dialog.exec_() != QtWidgets.QDialog.Accepted:
+            return
+        for path in dialog.selectedFiles():
+            try:
+                with open(path, "rb") as handle:
+                    content = base64.b64encode(handle.read()).decode("utf-8")
+            except OSError as exc:
+                QtWidgets.QMessageBox.warning(self, "提示", f"读取文件失败: {exc}")
+                continue
+            attachment = ExecutionAttachment(
+                file_name=QtCore.QFileInfo(path).fileName(),
+                content=f"data:image/{path.split('.')[-1]};base64,{content}",
+                size=os.path.getsize(path),
+            )
+            self.pending_attachments.append(attachment)
+            self.attachment_list.addItem(attachment.file_name)
+
+    def _clear_attachments(self) -> None:
+        self.pending_attachments.clear()
+        self.attachment_list.clear()
+
+    # ------------------------------------------------------------------
+    def accept(self) -> None:  # type: ignore[override]
+        remark = self.remark_edit.toPlainText().strip()
+        if not remark:
+            QtWidgets.QMessageBox.warning(self, "提示", "请填写备注信息")
+            return
+        if (
+            self.requires_attachment
+            and self.result != "blocked"
+            and not self.pending_attachments
+        ):
+            QtWidgets.QMessageBox.warning(
+                self, "提示", "该用例关键字包含时间，提交前必须上传图片"
+            )
+            return
+        super().accept()
+
+    # ------------------------------------------------------------------
+    def build_payload(
+        self,
+        *,
+        device_model_id: Optional[int],
+        plan_device_model_id: Optional[int],
+    ) -> ExecutionPayload:
+        remark = self.remark_edit.toPlainText().strip()
+        failure_reason = self.failure_reason_edit.toPlainText().strip() or None
+        bug_ref = self.bug_ref_edit.text().strip() or None
+        start_time = encode_timestamp(self.start_time_edit.dateTime().toPyDateTime())
+        end_time = encode_timestamp(self.end_time_edit.dateTime().toPyDateTime())
+        return ExecutionPayload(
+            plan_case_id=self.case.id,
+            result=self.result,
+            remark=remark,
+            failure_reason=failure_reason,
+            bug_ref=bug_ref,
+            execution_start_time=start_time,
+            execution_end_time=end_time,
+            attachments=list(self.pending_attachments),
+            device_model_id=device_model_id,
+            plan_device_model_id=plan_device_model_id,
+        )

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,20 +1,18 @@
 """Main application window for the PATVS client."""
 from __future__ import annotations
 
-import base64
-import os
 import re
 from datetime import datetime
-from typing import List, Optional, Sequence, Tuple
+from typing import List, Optional, Tuple
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt5 import QtCore, QtWidgets
 
 from ..api.client import ApiClient, ApiError
-from ..models import ExecutionAttachment, ExecutionPayload, PlanCase, Plan
+from ..models import Plan, PlanCase, PlanDeviceModel
 from ..monitoring.controller import MonitoringController
 from ..monitoring.keymaps import normalize_keyword
-from ..settings import PlanFilters, SettingsStore
-from ..utils.encryption import encode_timestamp
+from ..settings import SettingsStore
+from .execution_result_dialog import ExecutionResultDialog
 
 
 class MainWindow(QtWidgets.QMainWindow):
@@ -37,13 +35,13 @@ class MainWindow(QtWidgets.QMainWindow):
         self.current_plan: Optional[Plan] = None
         self.available_plans: List[Plan] = []
         self.plan_cases: List[PlanCase] = []
-        self.pending_attachments: List[ExecutionAttachment] = []
+        self.plan_device_models: List[PlanDeviceModel] = []
+        self.current_device_model: Optional[PlanDeviceModel] = None
 
         self.setWindowTitle("PATVS 桌面客户端")
         self.resize(1280, 800)
         self._build_ui()
         self._connect_signals()
-        self._load_initial_filters()
         self._load_departments()
 
     # ------------------------------------------------------------------
@@ -52,13 +50,29 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setCentralWidget(central_widget)
         layout = QtWidgets.QVBoxLayout(central_widget)
 
-        # Filters -------------------------------------------------------
         filter_group = QtWidgets.QGroupBox("计划筛选")
         filter_layout = QtWidgets.QGridLayout(filter_group)
 
         self.department_combo = QtWidgets.QComboBox()
         self.project_combo = QtWidgets.QComboBox()
         self.plan_combo = QtWidgets.QComboBox()
+        self.device_combo = QtWidgets.QComboBox()
+
+        for combo in (
+            self.department_combo,
+            self.project_combo,
+            self.plan_combo,
+            self.device_combo,
+        ):
+            combo.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
+
+        self.department_combo.addItem("请选择部门", None)
+        self.project_combo.addItem("请选择项目", None)
+        self.project_combo.setEnabled(False)
+        self.plan_combo.addItem("请选择计划", None)
+        self.plan_combo.setEnabled(False)
+        self.device_combo.addItem("请选择机型", None)
+        self.device_combo.setEnabled(False)
 
         filter_layout.addWidget(QtWidgets.QLabel("部门"), 0, 0)
         filter_layout.addWidget(self.department_combo, 0, 1)
@@ -66,174 +80,218 @@ class MainWindow(QtWidgets.QMainWindow):
         filter_layout.addWidget(self.project_combo, 0, 3)
         filter_layout.addWidget(QtWidgets.QLabel("计划"), 0, 4)
         filter_layout.addWidget(self.plan_combo, 0, 5)
-
-        self.directory_edit = QtWidgets.QLineEdit()
-        self.directory_edit.setPlaceholderText("目录关键词")
-        self.device_model_edit = QtWidgets.QLineEdit()
-        self.device_model_edit.setPlaceholderText("机型关键词")
-        self.priority_combo = QtWidgets.QComboBox()
-        self.priority_combo.addItems(["", "P0", "P1", "P2", "P3"])
-        self.result_combo = QtWidgets.QComboBox()
-        self.result_combo.addItems(["", "pass", "fail", "blocked", "pending"])
-
-        filter_layout.addWidget(QtWidgets.QLabel("目录"), 1, 0)
-        filter_layout.addWidget(self.directory_edit, 1, 1)
-        filter_layout.addWidget(QtWidgets.QLabel("机型"), 1, 2)
-        filter_layout.addWidget(self.device_model_edit, 1, 3)
-        filter_layout.addWidget(QtWidgets.QLabel("优先级"), 1, 4)
-        filter_layout.addWidget(self.priority_combo, 1, 5)
-        filter_layout.addWidget(QtWidgets.QLabel("结果"), 1, 6)
-        filter_layout.addWidget(self.result_combo, 1, 7)
-
-        self.refresh_button = QtWidgets.QPushButton("加载用例")
-        filter_layout.addWidget(self.refresh_button, 0, 6, 1, 2)
+        filter_layout.addWidget(QtWidgets.QLabel("机型"), 0, 6)
+        filter_layout.addWidget(self.device_combo, 0, 7)
+        filter_layout.setColumnStretch(1, 1)
+        filter_layout.setColumnStretch(3, 1)
+        filter_layout.setColumnStretch(5, 1)
+        filter_layout.setColumnStretch(7, 1)
 
         layout.addWidget(filter_group)
 
-        # Case table ----------------------------------------------------
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        layout.addWidget(splitter, stretch=1)
+
+        # Left panel with case list and monitoring controls
+        left_container = QtWidgets.QWidget()
+        left_layout = QtWidgets.QVBoxLayout(left_container)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+        left_layout.setSpacing(10)
+
         self.case_table = QtWidgets.QTableWidget(0, 6)
-        self.case_table.setHorizontalHeaderLabels([
-            "用例ID",
-            "标题",
-            "优先级",
-            "目录",
-            "最新结果",
-            "关键字",
-        ])
+        self.case_table.setHorizontalHeaderLabels(
+            ["用例ID", "标题", "优先级", "目录", "最新结果", "关键字"]
+        )
         self.case_table.horizontalHeader().setStretchLastSection(True)
         self.case_table.setSelectionBehavior(QtWidgets.QTableView.SelectRows)
         self.case_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
-        layout.addWidget(self.case_table)
+        self.case_table.setAlternatingRowColors(True)
+        left_layout.addWidget(self.case_table, stretch=1)
 
-        # Action buttons ------------------------------------------------
         action_layout = QtWidgets.QHBoxLayout()
-        self.view_case_button = QtWidgets.QPushButton("查看详情")
         self.start_monitor_button = QtWidgets.QPushButton("开始监控")
         self.stop_monitor_button = QtWidgets.QPushButton("停止监控")
-        action_layout.addWidget(self.view_case_button)
         action_layout.addWidget(self.start_monitor_button)
         action_layout.addWidget(self.stop_monitor_button)
         action_layout.addStretch()
-        layout.addLayout(action_layout)
+        left_layout.addLayout(action_layout)
 
-        # Result section ------------------------------------------------
-        result_group = QtWidgets.QGroupBox("用例结果记录")
-        result_layout = QtWidgets.QGridLayout(result_group)
-        self.result_selector = QtWidgets.QComboBox()
-        self.result_selector.addItems(["pass", "fail", "blocked", "pending"])
-        self.remark_edit = QtWidgets.QPlainTextEdit()
-        self.remark_edit.setPlaceholderText("备注 / 评论")
-        self.failure_reason_edit = QtWidgets.QPlainTextEdit()
-        self.failure_reason_edit.setPlaceholderText("失败或阻塞原因（可选）")
-        self.bug_ref_edit = QtWidgets.QLineEdit()
-        self.bug_ref_edit.setPlaceholderText("缺陷编号（可选）")
-
-        self.execution_start_edit = QtWidgets.QDateTimeEdit(QtCore.QDateTime.currentDateTime())
-        self.execution_start_edit.setCalendarPopup(True)
-        self.execution_end_edit = QtWidgets.QDateTimeEdit(QtCore.QDateTime.currentDateTime())
-        self.execution_end_edit.setCalendarPopup(True)
-
-        self.device_model_id_edit = QtWidgets.QLineEdit()
-        self.device_model_id_edit.setPlaceholderText("设备型号 ID（可选）")
-        self.plan_device_model_id_edit = QtWidgets.QLineEdit()
-        self.plan_device_model_id_edit.setPlaceholderText("计划设备 ID（可选）")
-
-        self.attachment_list = QtWidgets.QListWidget()
-        self.add_attachment_button = QtWidgets.QPushButton("添加图片")
-        self.clear_attachment_button = QtWidgets.QPushButton("清空图片")
-        self.submit_result_button = QtWidgets.QPushButton("提交结果")
-
-        result_layout.addWidget(QtWidgets.QLabel("结果"), 0, 0)
-        result_layout.addWidget(self.result_selector, 0, 1)
-        result_layout.addWidget(QtWidgets.QLabel("缺陷编号"), 0, 2)
-        result_layout.addWidget(self.bug_ref_edit, 0, 3)
-        result_layout.addWidget(QtWidgets.QLabel("开始时间"), 1, 0)
-        result_layout.addWidget(self.execution_start_edit, 1, 1)
-        result_layout.addWidget(QtWidgets.QLabel("结束时间"), 1, 2)
-        result_layout.addWidget(self.execution_end_edit, 1, 3)
-        result_layout.addWidget(QtWidgets.QLabel("备注"), 2, 0)
-        result_layout.addWidget(self.remark_edit, 2, 1, 1, 3)
-        result_layout.addWidget(QtWidgets.QLabel("失败原因"), 3, 0)
-        result_layout.addWidget(self.failure_reason_edit, 3, 1, 1, 3)
-        result_layout.addWidget(QtWidgets.QLabel("设备 ID"), 4, 0)
-        result_layout.addWidget(self.device_model_id_edit, 4, 1)
-        result_layout.addWidget(QtWidgets.QLabel("计划设备 ID"), 4, 2)
-        result_layout.addWidget(self.plan_device_model_id_edit, 4, 3)
-        result_layout.addWidget(QtWidgets.QLabel("图片附件"), 5, 0)
-        result_layout.addWidget(self.attachment_list, 5, 1, 2, 2)
-
-        button_column = QtWidgets.QVBoxLayout()
-        button_column.addWidget(self.add_attachment_button)
-        button_column.addWidget(self.clear_attachment_button)
-        button_column.addWidget(self.submit_result_button)
-        button_column.addStretch()
-        result_layout.addLayout(button_column, 5, 3)
-
-        layout.addWidget(result_group)
-
-        # Log area ------------------------------------------------------
         log_group = QtWidgets.QGroupBox("监控日志")
         log_layout = QtWidgets.QVBoxLayout(log_group)
         self.log_view = QtWidgets.QPlainTextEdit()
         self.log_view.setReadOnly(True)
         log_layout.addWidget(self.log_view)
-        layout.addWidget(log_group)
+        left_layout.addWidget(log_group, stretch=1)
+
+        splitter.addWidget(left_container)
+
+        # Right panel with case details and result actions
+        right_container = QtWidgets.QWidget()
+        right_layout = QtWidgets.QVBoxLayout(right_container)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+        right_layout.setSpacing(10)
+
+        detail_group = QtWidgets.QGroupBox("用例详情")
+        detail_layout = QtWidgets.QVBoxLayout(detail_group)
+
+        self.case_title_label = QtWidgets.QLabel("请选择一个用例")
+        self.case_title_label.setWordWrap(True)
+        self.case_title_label.setStyleSheet("font-size: 16px; font-weight: 600;")
+        detail_layout.addWidget(self.case_title_label)
+
+        info_grid = QtWidgets.QGridLayout()
+        info_grid.addWidget(QtWidgets.QLabel("优先级"), 0, 0)
+        self.case_priority_label = QtWidgets.QLabel("-")
+        info_grid.addWidget(self.case_priority_label, 0, 1)
+        info_grid.addWidget(QtWidgets.QLabel("最新结果"), 0, 2)
+        self.case_result_label = QtWidgets.QLabel("-")
+        info_grid.addWidget(self.case_result_label, 0, 3)
+        info_grid.addWidget(QtWidgets.QLabel("目录"), 1, 0)
+        self.case_directory_label = QtWidgets.QLabel("-")
+        self.case_directory_label.setWordWrap(True)
+        info_grid.addWidget(self.case_directory_label, 1, 1, 1, 3)
+        info_grid.addWidget(QtWidgets.QLabel("关键字"), 2, 0)
+        self.case_keywords_label = QtWidgets.QLabel("-")
+        self.case_keywords_label.setWordWrap(True)
+        info_grid.addWidget(self.case_keywords_label, 2, 1, 1, 3)
+        detail_layout.addLayout(info_grid)
+
+        detail_layout.addWidget(QtWidgets.QLabel("前置条件"))
+        self.case_preconditions_view = QtWidgets.QPlainTextEdit()
+        self.case_preconditions_view.setReadOnly(True)
+        self.case_preconditions_view.setMaximumHeight(100)
+        detail_layout.addWidget(self.case_preconditions_view)
+
+        detail_layout.addWidget(QtWidgets.QLabel("预期结果"))
+        self.case_expected_view = QtWidgets.QPlainTextEdit()
+        self.case_expected_view.setReadOnly(True)
+        self.case_expected_view.setMaximumHeight(120)
+        detail_layout.addWidget(self.case_expected_view)
+
+        self.case_steps_table = QtWidgets.QTableWidget(0, 3)
+        self.case_steps_table.setHorizontalHeaderLabels(["序号", "操作步骤", "预期结果"])
+        self.case_steps_table.horizontalHeader().setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeToContents)
+        self.case_steps_table.horizontalHeader().setSectionResizeMode(1, QtWidgets.QHeaderView.Stretch)
+        self.case_steps_table.horizontalHeader().setSectionResizeMode(2, QtWidgets.QHeaderView.Stretch)
+        self.case_steps_table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.case_steps_table.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
+        detail_layout.addWidget(self.case_steps_table, stretch=1)
+
+        right_layout.addWidget(detail_group, stretch=1)
+
+        result_group = QtWidgets.QGroupBox("记录结果")
+        result_layout = QtWidgets.QVBoxLayout(result_group)
+        button_row = QtWidgets.QHBoxLayout()
+        self.pass_button = QtWidgets.QPushButton("标记通过")
+        self.fail_button = QtWidgets.QPushButton("标记失败")
+        self.block_button = QtWidgets.QPushButton("标记阻塞")
+        button_row.addWidget(self.pass_button)
+        button_row.addWidget(self.fail_button)
+        button_row.addWidget(self.block_button)
+        button_row.addStretch()
+        result_layout.addLayout(button_row)
+        hint_label = QtWidgets.QLabel("点击按钮后将在弹窗中填写详细结果")
+        hint_label.setStyleSheet("color: #555555;")
+        result_layout.addWidget(hint_label)
+        right_layout.addWidget(result_group)
+        right_layout.addStretch(1)
+
+        splitter.addWidget(right_container)
+        splitter.setStretchFactor(0, 3)
+        splitter.setStretchFactor(1, 2)
 
         status_bar = self.statusBar()
-        status_bar.showMessage(f"当前用户: {self.user_info.get('real_name') or self.user_info.get('username')}")
+        status_bar.showMessage(
+            f"当前用户: {self.user_info.get('real_name') or self.user_info.get('username')}"
+        )
 
     # ------------------------------------------------------------------
     def _connect_signals(self) -> None:
         self.department_combo.currentIndexChanged.connect(self._on_department_changed)
         self.project_combo.currentIndexChanged.connect(self._on_project_changed)
         self.plan_combo.currentIndexChanged.connect(self._on_plan_changed)
-        self.refresh_button.clicked.connect(self._load_cases)
-        self.case_table.itemSelectionChanged.connect(self._update_execution_form)
-        self.view_case_button.clicked.connect(self._open_case_details)
+        self.device_combo.currentIndexChanged.connect(self._on_device_changed)
+        self.case_table.itemSelectionChanged.connect(self._update_case_detail)
         self.start_monitor_button.clicked.connect(self._start_monitoring)
         self.stop_monitor_button.clicked.connect(self.monitoring.stop)
-        self.add_attachment_button.clicked.connect(self._add_attachment)
-        self.clear_attachment_button.clicked.connect(self._clear_attachments)
-        self.submit_result_button.clicked.connect(self._submit_result)
+        self.pass_button.clicked.connect(lambda: self._record_result("pass"))
+        self.fail_button.clicked.connect(lambda: self._record_result("fail"))
+        self.block_button.clicked.connect(lambda: self._record_result("blocked"))
         self.monitoring.log_generated.connect(self._append_log)
         self.monitoring.monitoring_finished.connect(lambda: self._append_log("监控任务已完成"))
         self.monitoring.monitoring_error.connect(self._handle_monitor_error)
 
     # ------------------------------------------------------------------
-    def _load_initial_filters(self) -> None:
-        filters = self.settings.get_filters()
-        if filters.directory:
-            self.directory_edit.setText(filters.directory)
-        if filters.device_model:
-            self.device_model_edit.setText(filters.device_model)
-        if filters.priority:
-            index = self.priority_combo.findText(filters.priority)
-            if index >= 0:
-                self.priority_combo.setCurrentIndex(index)
-        if filters.result:
-            index = self.result_combo.findText(filters.result)
-            if index >= 0:
-                self.result_combo.setCurrentIndex(index)
+    def _reset_project_combo(self) -> None:
+        self.project_combo.blockSignals(True)
+        self.project_combo.clear()
+        self.project_combo.addItem("请选择项目", None)
+        self.project_combo.blockSignals(False)
+        self.project_combo.setEnabled(False)
+        self.current_project_id = None
+
+    def _reset_plan_combo(self) -> None:
+        self.plan_combo.blockSignals(True)
+        self.plan_combo.clear()
+        self.plan_combo.addItem("请选择计划", None)
+        self.plan_combo.blockSignals(False)
+        self.plan_combo.setEnabled(False)
+        self.current_plan = None
+        self.available_plans = []
+
+    def _reset_device_combo(self) -> None:
+        self.device_combo.blockSignals(True)
+        self.device_combo.clear()
+        self.device_combo.addItem("请选择机型", None)
+        self.device_combo.blockSignals(False)
+        self.device_combo.setEnabled(False)
+        self.plan_device_models = []
+        self.current_device_model = None
+
+    def _clear_cases(self) -> None:
+        self.plan_cases = []
+        self.case_table.setRowCount(0)
+        self._clear_case_detail()
 
     # ------------------------------------------------------------------
     def _load_departments(self) -> None:
+        self.department_combo.blockSignals(True)
         self.department_combo.clear()
+        self.department_combo.addItem("请选择部门", None)
+        self.department_combo.blockSignals(False)
+        self.department_combo.setEnabled(False)
+        self._reset_project_combo()
+        self._reset_plan_combo()
+        self._reset_device_combo()
+        self._clear_cases()
         try:
             departments = self.api_client.get_departments()
         except ApiError as exc:
             self._show_error(str(exc))
             return
+        self.department_combo.blockSignals(True)
         for dept in departments:
             self.department_combo.addItem(dept.name, dept.id)
-        if departments:
-            self.current_department_id = departments[0].id
+        self.department_combo.blockSignals(False)
+        self.department_combo.setEnabled(bool(departments))
 
     def _on_department_changed(self, index: int) -> None:
-        self.current_department_id = self.department_combo.itemData(index)
+        dept_id = self.department_combo.itemData(index)
+        if not dept_id:
+            self.current_department_id = None
+            self._reset_project_combo()
+            self._reset_plan_combo()
+            self._reset_device_combo()
+            self._clear_cases()
+            return
+        self.current_department_id = dept_id
         self._load_projects()
 
     def _load_projects(self) -> None:
-        self.project_combo.clear()
+        self._reset_project_combo()
+        self._reset_plan_combo()
+        self._reset_device_combo()
+        self._clear_cases()
         if not self.current_department_id:
             return
         try:
@@ -241,37 +299,50 @@ class MainWindow(QtWidgets.QMainWindow):
         except ApiError as exc:
             self._show_error(str(exc))
             return
+        self.project_combo.blockSignals(True)
         for project in projects:
             self.project_combo.addItem(project.name, project.id)
-        if projects:
-            self.current_project_id = projects[0].id
-            self._load_plans()
+        self.project_combo.blockSignals(False)
+        self.project_combo.setEnabled(bool(projects))
 
     def _on_project_changed(self, index: int) -> None:
-        self.current_project_id = self.project_combo.itemData(index)
+        project_id = self.project_combo.itemData(index)
+        if not project_id:
+            self.current_project_id = None
+            self._reset_plan_combo()
+            self._reset_device_combo()
+            self._clear_cases()
+            return
+        self.current_project_id = project_id
         self._load_plans()
 
     def _load_plans(self) -> None:
-        self.plan_combo.clear()
+        self._reset_plan_combo()
+        self._reset_device_combo()
+        self._clear_cases()
         if not self.current_department_id or not self.current_project_id:
             return
         try:
-            plans = self.api_client.get_plans(self.current_department_id, self.current_project_id)
+            plans = self.api_client.get_plans(
+                self.current_department_id, self.current_project_id
+            )
         except ApiError as exc:
             self._show_error(str(exc))
             return
         self.available_plans = plans
+        self.plan_combo.blockSignals(True)
         for plan in plans:
             self.plan_combo.addItem(plan.name, plan.id)
-        if plans:
-            self.current_plan = plans[0]
-            self._load_cases()
+        self.plan_combo.blockSignals(False)
+        self.plan_combo.setEnabled(bool(plans))
 
     def _on_plan_changed(self, index: int) -> None:
-        if index < 0 or index >= len(self.available_plans):
+        if index <= 0 or index - 1 >= len(self.available_plans):
             plan_id = self.plan_combo.itemData(index)
             if plan_id is None:
                 self.current_plan = None
+                self._reset_device_combo()
+                self._clear_cases()
                 return
             self.current_plan = Plan(
                 id=plan_id,
@@ -281,30 +352,46 @@ class MainWindow(QtWidgets.QMainWindow):
                 status="unknown",
             )
         else:
-            self.current_plan = self.available_plans[index]
+            self.current_plan = self.available_plans[index - 1]
+        self._load_plan_devices()
+
+    def _load_plan_devices(self) -> None:
+        self._reset_device_combo()
+        self._clear_cases()
+        if not self.current_plan:
+            return
+        try:
+            devices = self.api_client.get_plan_device_models(self.current_plan.id)
+        except ApiError as exc:
+            self._show_error(str(exc))
+            return
+        self.plan_device_models = devices
+        self.device_combo.blockSignals(True)
+        for model in devices:
+            display = model.name or model.model_code or f"设备 {model.device_model_id or ''}"
+            self.device_combo.addItem(display, model)
+        self.device_combo.blockSignals(False)
+        self.device_combo.setEnabled(bool(devices))
+
+    def _on_device_changed(self, index: int) -> None:
+        data = self.device_combo.itemData(index)
+        if not isinstance(data, PlanDeviceModel):
+            self.current_device_model = None
+            self._clear_cases()
+            return
+        self.current_device_model = data
         self._load_cases()
 
     # ------------------------------------------------------------------
-    def _collect_filters(self) -> PlanFilters:
-        return PlanFilters(
-            directory=self.directory_edit.text().strip() or None,
-            device_model=self.device_model_edit.text().strip() or None,
-            priority=self.priority_combo.currentText() or None,
-            result=self.result_combo.currentText() or None,
-        )
-
     def _load_cases(self) -> None:
-        if not self.current_plan:
+        if not self.current_plan or not self.current_device_model:
+            self._clear_cases()
             return
-        filters = self._collect_filters()
-        self.settings.save_filters(filters)
+        device_filter = self.current_device_model.name or self.current_device_model.model_code
         try:
             cases = self.api_client.get_plan_cases(
                 self.current_plan.id,
-                directory=filters.directory,
-                device_model=filters.device_model,
-                priority=filters.priority,
-                result=filters.result,
+                device_model=device_filter,
             )
         except ApiError as exc:
             self._show_error(str(exc))
@@ -319,13 +406,19 @@ class MainWindow(QtWidgets.QMainWindow):
             self.case_table.setItem(row, 1, QtWidgets.QTableWidgetItem(case.title))
             self.case_table.setItem(row, 2, QtWidgets.QTableWidgetItem(case.priority))
             self.case_table.setItem(row, 3, QtWidgets.QTableWidgetItem(case.group_path))
-            self.case_table.setItem(row, 4, QtWidgets.QTableWidgetItem(case.latest_result or ""))
-            self.case_table.setItem(row, 5, QtWidgets.QTableWidgetItem(", ".join(case.keywords)))
+            self.case_table.setItem(
+                row, 4, QtWidgets.QTableWidgetItem(case.latest_result or "")
+            )
+            self.case_table.setItem(
+                row,
+                5,
+                QtWidgets.QTableWidgetItem(", ".join(case.keywords) if case.keywords else ""),
+            )
         self.case_table.resizeColumnsToContents()
         if self.plan_cases:
             self.case_table.selectRow(0)
         else:
-            self._clear_execution_form()
+            self._clear_case_detail()
 
     # ------------------------------------------------------------------
     def _selected_case(self) -> Optional[PlanCase]:
@@ -337,42 +430,54 @@ class MainWindow(QtWidgets.QMainWindow):
             return None
         return self.plan_cases[index]
 
-    def _update_execution_form(self) -> None:
-        self.pending_attachments.clear()
-        self.attachment_list.clear()
+    def _clear_case_detail(self) -> None:
+        self.case_title_label.setText("请选择一个用例")
+        self.case_priority_label.setText("-")
+        self.case_result_label.setText("-")
+        self.case_directory_label.setText("-")
+        self.case_keywords_label.setText("-")
+        self.case_preconditions_view.clear()
+        self.case_expected_view.clear()
+        self.case_steps_table.setRowCount(0)
+
+    def _update_case_detail(self) -> None:
         case = self._selected_case()
         if not case:
-            self._clear_execution_form()
+            self._clear_case_detail()
             return
-        self.remark_edit.clear()
-        self.failure_reason_edit.clear()
-        self.bug_ref_edit.clear()
-        self.execution_start_edit.setDateTime(QtCore.QDateTime.currentDateTime())
-        self.execution_end_edit.setDateTime(QtCore.QDateTime.currentDateTime())
-        self.device_model_id_edit.clear()
-        self.plan_device_model_id_edit.clear()
-        self.statusBar().showMessage(f"选中用例: {case.title}")
+        self.case_title_label.setText(case.title)
+        self.case_priority_label.setText(case.priority or "-")
+        self.case_result_label.setText(case.latest_result or "-")
+        self.case_directory_label.setText(case.group_path or "-")
+        keywords = ", ".join(case.keywords) if case.keywords else "-"
+        self.case_keywords_label.setText(keywords)
+        self.case_preconditions_view.setPlainText(case.preconditions or "无")
+        self.case_expected_view.setPlainText(case.expected_result or "无")
 
-    def _clear_execution_form(self) -> None:
-        self.remark_edit.clear()
-        self.failure_reason_edit.clear()
-        self.bug_ref_edit.clear()
-        self.attachment_list.clear()
-        self.pending_attachments.clear()
+        steps = list(case.steps or [])
+        self.case_steps_table.setRowCount(len(steps))
+        for row, step in enumerate(steps):
+            if isinstance(step, dict):
+                no = step.get("no") or row + 1
+                action = step.get("action", "")
+                expected = step.get("expected", "")
+            else:
+                no = getattr(step, "no", row + 1)
+                action = getattr(step, "action", "")
+                expected = getattr(step, "expected", "")
+            self.case_steps_table.setItem(row, 0, QtWidgets.QTableWidgetItem(str(no)))
+            self.case_steps_table.setItem(row, 1, QtWidgets.QTableWidgetItem(action))
+            self.case_steps_table.setItem(row, 2, QtWidgets.QTableWidgetItem(expected))
 
-    # ------------------------------------------------------------------
-    def _open_case_details(self) -> None:
-        case = self._selected_case()
-        if not case:
-            self._show_error("请先选择一个用例")
-            return
-        if not self.current_plan:
-            self._show_error("请先选择一个测试计划")
-            return
-        from .case_detail_dialog import CaseDetailDialog
-
-        dialog = CaseDetailDialog(case, self)
-        dialog.exec_()
+        status = f"选中用例: {case.title}"
+        if self.current_device_model:
+            model_name = (
+                self.current_device_model.name
+                or self.current_device_model.model_code
+                or str(self.current_device_model.device_model_id or "")
+            )
+            status += f" | 机型: {model_name}"
+        self.statusBar().showMessage(status)
 
     # ------------------------------------------------------------------
     def _parse_keywords(self, case: PlanCase) -> List[Tuple[str, float]]:
@@ -417,74 +522,32 @@ class MainWindow(QtWidgets.QMainWindow):
         self._append_log(f"已启动监控: {case.title}")
 
     # ------------------------------------------------------------------
-    def _add_attachment(self) -> None:
-        file_dialog = QtWidgets.QFileDialog(self, "选择图片")
-        file_dialog.setFileMode(QtWidgets.QFileDialog.ExistingFiles)
-        file_dialog.setNameFilters(["图片文件 (*.png *.jpg *.jpeg *.bmp)"])
-        if file_dialog.exec_() != QtWidgets.QDialog.Accepted:
-            return
-        for file_path in file_dialog.selectedFiles():
-            try:
-                with open(file_path, "rb") as fh:
-                    content = base64.b64encode(fh.read()).decode("utf-8")
-            except OSError as exc:
-                self._show_error(f"读取文件失败: {exc}")
-                continue
-            attachment = ExecutionAttachment(
-                file_name=QtCore.QFileInfo(file_path).fileName(),
-                content=f"data:image/{file_path.split('.')[-1]};base64,{content}",
-                size=os.path.getsize(file_path),
-            )
-            self.pending_attachments.append(attachment)
-            self.attachment_list.addItem(attachment.file_name)
-
-    def _clear_attachments(self) -> None:
-        self.pending_attachments.clear()
-        self.attachment_list.clear()
-
-    # ------------------------------------------------------------------
-    def _build_execution_payload(self, case: PlanCase) -> ExecutionPayload:
-        result = self.result_selector.currentText()
-        remark = self.remark_edit.toPlainText().strip()
-        failure_reason = self.failure_reason_edit.toPlainText().strip() or None
-        bug_ref = self.bug_ref_edit.text().strip() or None
-        start_time = encode_timestamp(self.execution_start_edit.dateTime().toPyDateTime())
-        end_time = encode_timestamp(self.execution_end_edit.dateTime().toPyDateTime())
-        device_model_id = self._parse_optional_int(self.device_model_id_edit.text())
-        plan_device_model_id = self._parse_optional_int(self.plan_device_model_id_edit.text())
-        return ExecutionPayload(
-            plan_case_id=case.id,
-            result=result,
-            remark=remark,
-            failure_reason=failure_reason,
-            bug_ref=bug_ref,
-            execution_start_time=start_time,
-            execution_end_time=end_time,
-            attachments=list(self.pending_attachments),
-            device_model_id=device_model_id,
-            plan_device_model_id=plan_device_model_id,
-        )
-
-    def _submit_result(self) -> None:
+    def _record_result(self, result: str) -> None:
         case = self._selected_case()
         if not case:
             self._show_error("请先选择一个用例")
             return
-        requires_attachment = False
+        if not self.current_plan:
+            self._show_error("请先选择一个测试计划")
+            return
+        if not self.current_device_model:
+            self._show_error("请先选择一个机型")
+            return
         try:
             actions = self._parse_keywords(case)
-            requires_attachment = any("时间" in normalize_keyword(action)[0] for action, _ in actions)
         except ValueError as exc:
             self._show_error(str(exc))
             return
-        result = self.result_selector.currentText()
-        if requires_attachment and result != "blocked" and not self.pending_attachments:
-            self._show_error("该用例关键字包含时间，提交结果前必须上传图片")
+        requires_attachment = any(
+            "时间" in normalize_keyword(action)[0] for action, _ in actions
+        )
+        dialog = ExecutionResultDialog(case, result, requires_attachment, self)
+        if dialog.exec_() != QtWidgets.QDialog.Accepted:
             return
-        payload = self._build_execution_payload(case)
-        if not payload.remark:
-            self._show_error("请填写备注信息")
-            return
+        payload = dialog.build_payload(
+            device_model_id=self.current_device_model.device_model_id,
+            plan_device_model_id=self.current_device_model.plan_device_model_id,
+        )
         try:
             response = self.api_client.post_execution_result(self.current_plan.id, payload)
         except ApiError as exc:
@@ -503,15 +566,5 @@ class MainWindow(QtWidgets.QMainWindow):
         self._show_error(message)
 
     # ------------------------------------------------------------------
-    def _parse_optional_int(self, value: str) -> Optional[int]:
-        value = value.strip()
-        if not value:
-            return None
-        try:
-            return int(value)
-        except ValueError:
-            self._show_error(f"请输入有效的数字: {value}")
-            return None
-
     def _show_error(self, message: str) -> None:
         QtWidgets.QMessageBox.critical(self, "错误", message)


### PR DESCRIPTION
## Summary
- add hierarchical department/project/plan/device selectors and show case details in the main window
- move result recording into a modal dialog that pre-fills the selected device and supports attachments
- expose plan device models and parse case steps in the API client to support the new workflow

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_b_68f88c6b50988320ba635756aaea5def