### PR TITLE
Fix plan case details and keyword display

### DIFF
--- a/tts_client/core/models.py
+++ b/tts_client/core/models.py
@@ -1,6 +1,7 @@
 """Data models that mirror server side payloads."""
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -239,6 +240,27 @@ class CaseExecutionResult:
 
 
 @dataclass(slots=True)
+class CaseStep:
+    """Represents a single step within a plan case."""
+
+    no: Optional[int]
+    action: Optional[str]
+    expected: Optional[str]
+    keyword: Optional[str]
+    note: Optional[str]
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, Any]) -> "CaseStep":
+        return cls(
+            no=payload.get("no"),
+            action=payload.get("action"),
+            expected=payload.get("expected"),
+            keyword=payload.get("keyword"),
+            note=payload.get("note"),
+        )
+
+
+@dataclass(slots=True)
 class PlanCase:
     """Model for the `/test-plans/{plan}/cases` endpoint."""
 
@@ -247,11 +269,18 @@ class PlanCase:
     title: str
     priority: Optional[str]
     latest_result: Optional[str]
+    preconditions: Optional[str]
+    expected_result: Optional[str]
+    include: bool
+    require_all_devices: bool
+    order_no: Optional[int]
+    plan_id: Optional[int]
     keywords: List[str] = field(default_factory=list)
     group_path: Optional[str] = None
     workload_minutes: Optional[int] = None
     execution_results: List[CaseExecutionResult] = field(default_factory=list)
     device_models: List[DeviceModel] = field(default_factory=list)
+    steps: List[CaseStep] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, payload: Dict[str, Any]) -> "PlanCase":
@@ -261,6 +290,12 @@ class PlanCase:
             title=payload.get("title", ""),
             priority=payload.get("priority"),
             latest_result=payload.get("latest_result"),
+            preconditions=payload.get("preconditions"),
+            expected_result=payload.get("expected_result"),
+            include=payload.get("include", True),
+            require_all_devices=payload.get("require_all_devices", False),
+            order_no=payload.get("order_no"),
+            plan_id=payload.get("plan_id"),
             keywords=list(payload.get("keywords") or []),
             group_path=payload.get("group_path"),
             workload_minutes=payload.get("workload_minutes"),
@@ -269,12 +304,40 @@ class PlanCase:
                 for result in payload.get("execution_results", [])
             ],
             device_models=_collect_device_models(payload),
+            steps=[CaseStep.from_dict(step) for step in payload.get("steps", [])],
         )
 
     def keyword_actions(self) -> List[str]:
         """Return a sanitized list of keyword tokens."""
 
-        return [token.strip() for token in self.keywords if token]
+        return [
+            token
+            for token in self.keyword_tokens()
+            if "+" in token
+        ]
+
+    def keyword_tokens(self) -> List[str]:
+        """Return flattened keyword tokens for display and parsing."""
+
+        tokens: List[str] = []
+        splitter = re.compile(r"[\s,;，；]+")
+        for raw in self.keywords:
+            if not raw:
+                continue
+            if isinstance(raw, str):
+                parts = splitter.split(raw.strip())
+            else:  # pragma: no cover - defensive
+                parts = [str(raw)]
+            for part in parts:
+                part = part.strip()
+                if part:
+                    tokens.append(part)
+        return tokens
+
+    def display_keywords(self) -> str:
+        """Return keywords formatted for UI display."""
+
+        return " ".join(self.keyword_tokens())
 
 
 def _collect_device_models(payload: Dict[str, Any]) -> List[DeviceModel]:

--- a/tts_client/ui/main_window.py
+++ b/tts_client/ui/main_window.py
@@ -765,8 +765,11 @@ class MainWindow(QtWidgets.QMainWindow):
                     parent.addChild(node)
                     parents[key] = node
                 parent = parents[key]
-            item = QtWidgets.QTreeWidgetItem([case.title])
+            item = QtWidgets.QTreeWidgetItem([self._case_display_text(case)])
             item.setData(0, QtCore.Qt.UserRole, case)
+            keywords = case.display_keywords()
+            if keywords:
+                item.setToolTip(0, f"关键字: {keywords}")
             parent.addChild(item)
 
         self._case_tree.expandAll()
@@ -804,6 +807,33 @@ class MainWindow(QtWidgets.QMainWindow):
             return ["未分组"]
         return normalized.split("/")
 
+    def _case_status_symbol(self, case: PlanCase) -> str:
+        result = (case.latest_result or "").lower()
+        if not result and case.execution_results:
+            result = (case.execution_results[0].result or "").lower()
+        mapping = {
+            "pass": "√",
+            "fail": "×",
+            "blocked": "阻",
+            "block": "阻",
+            "pending": "…",
+            "notrun": "…",
+            "skipped": "跳",
+        }
+        return mapping.get(result, "")
+
+    def _case_display_text(self, case: PlanCase, include_status: bool = True) -> str:
+        parts: List[str] = []
+        status = self._case_status_symbol(case) if include_status else ""
+        if status:
+            parts.append(status)
+        title = (case.title or "").strip() or f"用例 {case.case_id}"
+        parts.append(title)
+        keywords = case.display_keywords()
+        if keywords:
+            parts.append(f"[{keywords}]")
+        return " ".join(parts)
+
     def _on_case_selected(
         self,
         current: Optional[QtWidgets.QTreeWidgetItem],
@@ -833,7 +863,7 @@ class MainWindow(QtWidgets.QMainWindow):
             self._attachment_hint.clear()
             return
 
-        self._title_label.setText(case.title)
+        self._title_label.setText(self._case_display_text(case))
 
         preconditions = (case.preconditions or "").strip()
         self._precondition_view.setPlainText(preconditions or "暂无前置条件")
@@ -921,7 +951,7 @@ class MainWindow(QtWidgets.QMainWindow):
         dialog = ResultDialog(
             self,
             {"pass": "通过", "fail": "失败", "blocked": "阻塞"}.get(result, result.upper()),
-            self._current_case.title,
+            self._case_display_text(self._current_case, include_status=False),
             self._current_device_options,
             need_attachment,
         )


### PR DESCRIPTION
## Summary
- add missing fields to PlanCase model so case details render correctly
- normalise and display keywords while adding status symbols in the case tree
- show detailed titles in dialogs and case view with appended keywords

## Testing
- python -m compileall tts_client/core/models.py tts_client/ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_b_68f9ac9e684c832082983b4b7875c613