### PR TITLE
Fix monitoring thread join logic

### DIFF
--- a/tts_client/monitoring/manager.py
+++ b/tts_client/monitoring/manager.py
@@ -60,7 +60,7 @@ class MonitoringManager(QtCore.QObject):
         self._thread = None
         if worker:
             worker.stop_event = False
-        if thread:
+        if thread and thread is not threading.current_thread():
             thread.join(timeout=0)
         self.monitoring_finished.emit()
 


### PR DESCRIPTION
## Summary
- prevent the monitoring manager from attempting to join the current thread while stopping

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f9e3745cf8832081eb999bc3cdae90