### PR TITLE
Fix monitoring countdown signaling and retain filter selections

### DIFF
--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -28,12 +28,23 @@ import cv2
 logger = logging.getLogger(__name__)
 
 
-class _WxCompat:
+class _WxCompat(QtCore.QObject):
     """Compatibility shim so legacy monitoring logic can run under PyQt."""
 
+    _call_after_signal = QtCore.pyqtSignal(object, tuple, dict)
+
+    def __init__(self):
+        super().__init__()
+        # Ensure callbacks are executed on the Qt main thread regardless of the
+        # originating worker thread.
+        self._call_after_signal.connect(self._invoke, QtCore.Qt.QueuedConnection)
+
+    def CallAfter(self, func, *args, **kwargs):
+        self._call_after_signal.emit(func, args, kwargs)
+
     @staticmethod
-    def CallAfter(func, *args, **kwargs):
-        QtCore.QTimer.singleShot(0, lambda: func(*args, **kwargs))
+    def _invoke(func, args, kwargs):
+        func(*args, **kwargs)
 
     class _App:
         @staticmethod

--- a/tts_client/ui/main_window.py
+++ b/tts_client/ui/main_window.py
@@ -209,6 +209,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._current_plan_device_model_id: Optional[int] = None
         self._execution_locked = False
         self._awaiting_monitor_completion_for_pass = False
+        self._pending_filter_state: Optional[Dict[str, object]] = None
 
         self.setWindowTitle("TTS 测试执行客户端")
         self.resize(1280, 720)
@@ -663,6 +664,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _on_plan_changed(self, index: int) -> None:
         if index < 0 or index >= len(self._plans):
+            self._pending_filter_state = None
             self._cases = []
             self._plan_detail = None
             self._update_plan_summary()
@@ -697,6 +699,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._refresh_directory_filter()
         self._refresh_device_filter()
+        self._restore_pending_filters()
         self._apply_filters()
 
     def _refresh_device_filter(self) -> None:
@@ -745,6 +748,37 @@ class MainWindow(QtWidgets.QMainWindow):
             self._directory_filter.addItem(directory, directory)
         self._directory_filter.blockSignals(False)
         self._directory_filter.setCurrentIndex(0)
+
+    def _set_combobox_current_data(
+        self, combo: QtWidgets.QComboBox, value: object
+    ) -> None:
+        combo.blockSignals(True)
+        try:
+            target_index = None
+            if value is None:
+                target_index = 0 if combo.count() else -1
+            else:
+                for index in range(combo.count()):
+                    if combo.itemData(index) == value:
+                        target_index = index
+                        break
+            if target_index is None:
+                target_index = 0 if combo.count() else -1
+            if target_index >= 0:
+                combo.setCurrentIndex(target_index)
+        finally:
+            combo.blockSignals(False)
+
+    def _restore_pending_filters(self) -> None:
+        if not self._pending_filter_state:
+            return
+        state = self._pending_filter_state
+        self._pending_filter_state = None
+        self._set_combobox_current_data(
+            self._directory_filter, state.get("directory")
+        )
+        self._set_combobox_current_data(self._device_filter, state.get("device"))
+        self._set_combobox_current_data(self._result_filter, state.get("result"))
 
     def _format_device_label(
         self,
@@ -1238,7 +1272,15 @@ class MainWindow(QtWidgets.QMainWindow):
     def _reload_current_plan(self) -> None:
         index = self._plan_combo.currentIndex()
         if index >= 0:
+            self._pending_filter_state = {
+                "directory": self._directory_filter.currentData(),
+                "device": self._device_filter.currentData(),
+                "result": self._result_filter.currentData(),
+            }
             self._on_plan_changed(index)
+            if self._pending_filter_state:
+                # 如果计划重新加载过程中未使用这些值，确保不要遗留旧状态。
+                self._pending_filter_state = None
 
     # ------------------------------------------------------------------
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # noqa: N802


### PR DESCRIPTION
## Summary
- ensure the legacy monitoring CallAfter implementation posts callbacks through a Qt queued signal so countdown updates appear in the UI
- persist the current directory, device, and result filters when reloading a plan after submitting a result

## Testing
- python -m compileall monitoring/patvs_monitor.py tts_client/ui/main_window.py

------
https://chatgpt.com/codex/tasks/task_b_68f9eca4e1bc8320bf659cc1e3f1f619