### PR TITLE
Reset PATVS monitoring progress when submitting case results

### DIFF
--- a/monitoring/manager.py
+++ b/monitoring/manager.py
@@ -31,6 +31,15 @@ class MonitoringManager(QtCore.QObject):
             return
         self._worker.is_running = False
 
+    def discard_session_state(self) -> None:
+        """Clear any persisted monitoring progress for the active worker."""
+
+        worker = self._worker
+        if worker is not None:
+            worker.request_session_reset()
+        else:
+            Patvs_Fuction.remove_temp_file()
+
     def start(self, case_id: int, actions: Sequence[MonitoringAction], start_time: str) -> None:
         if self.is_running():
             self.monitoring_error.emit("已有监控任务正在执行，请先停止当前任务")

--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -163,6 +163,7 @@ class Patvs_Fuction:
         self.audio_event_cache: dict[str, int] = {}
         self.case_start_time: str | None = None
         self.state_lock = threading.Lock()
+        self.session_reset_requested = False
 
     # ------------------------------------------------------------------
     def log(self, message: str) -> None:
@@ -401,7 +402,15 @@ class Patvs_Fuction:
                     return normalized_actions, data.get("start_time")
         return [], None
 
+    def request_session_reset(self):
+        """Mark the current session as invalid so it will not resume next time."""
+
+        self.session_reset_requested = True
+        self.remove_temp_file()
+
     def save_session_state(self):
+        if self.session_reset_requested:
+            return
         with self.state_lock:
             actions_snapshot = [dict(action) for action in self.remaining_actions]
             start_time = self.case_start_time
@@ -419,9 +428,10 @@ class Patvs_Fuction:
         with open(self.TEMP_FILE, "wb") as file:
             file.write(encrypted_data)
 
-    def remove_temp_file(self):
-        if os.path.exists(self.TEMP_FILE):
-            os.remove(self.TEMP_FILE)
+    @classmethod
+    def remove_temp_file(cls):
+        if os.path.exists(cls.TEMP_FILE):
+            os.remove(cls.TEMP_FILE)
 
     def normalize_action(self, action):
         return action.lower().replace(" ", "")
@@ -666,7 +676,7 @@ class Patvs_Fuction:
 
             with self.state_lock:
                 has_remaining = bool(self.remaining_actions)
-            if not has_remaining:
+            if not has_remaining or self.session_reset_requested:
                 self.logger.warning("所有动作执行完毕，开始删除临时文件")
                 self.remove_temp_file()
             else:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1792,6 +1792,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if self._monitoring.is_running():
             self._monitoring.stop()
             self._append_log("监控停止请求已发送")
+        self._monitoring.discard_session_state()
         self._awaiting_monitor_completion_for_pass = False
         try:
             self._api.submit_result(


### PR DESCRIPTION
## Summary
- prevent PATVS monitoring sessions from persisting progress after a result is submitted
- expose a monitoring manager helper to discard any stored session state
- ensure result submissions always clear previous monitoring progress so new runs start fresh

## Testing
- not run (environment-specific tooling not available)


------
https://chatgpt.com/codex/tasks/task_b_6908144d5c7c8320908b3ba8caf7ac91