### PR TITLE
Centralize local storage paths in config settings

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -39,9 +39,11 @@ class ClientSettings:
     api: ApiSettings = ApiSettings()
     ota: OTASettings = OTASettings()
     remember_me_file: Path = PATVS_ROOT / "credentials.json"
+    ui_state_file: Path = CONFIG_DIR / "ui_state.json"
     window_state_file: Path = CONFIG_DIR / "window_state.json"
     monitoring_cache_file: Path = CONFIG_DIR / "monitoring_state.json"
     log_root: Path = PATVS_ROOT
+    monitoring_temp_file: Path = PATVS_ROOT / "temp_action_and_num.json"
 
 
 SETTINGS = ClientSettings()

--- a/monitoring/audio_event_constants.py
+++ b/monitoring/audio_event_constants.py
@@ -5,7 +5,9 @@ Each event code maps to a spec with keywords and a human-readable description.
 """
 from typing import Dict, List, Optional, TypedDict
 
-DEFAULT_LOG_DIR: str = r"C:\\PATVS\\logs"
+from config.settings import SETTINGS
+
+DEFAULT_LOG_DIR: str = str(SETTINGS.log_root / "logs")
 DEFAULT_FILE_PATTERNS: List[str] = ['*.log', '*.txt']
 
 class EventSpec(TypedDict):

--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -5,7 +5,6 @@ import datetime
 import json
 import logging
 import math
-import os
 import threading
 import time
 from typing import Callable
@@ -35,6 +34,7 @@ from .actions import (
     usb_monitor,
     volume_monitor,
 )
+from config.settings import SETTINGS
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 class Patvs_Fuction:
     """负责任务编排的监控上下文。"""
 
-    TEMP_FILE = r"C:\PATVS\temp_action_and_num.json"
+    TEMP_FILE = SETTINGS.monitoring_temp_file
     ENCRYPTION_KEY = b"JZfpG9N5K4PQoQMtImxPv80DS-D-WPXr9DN0eF7zhR4="
 
     KEY_MAPPING = {
@@ -388,8 +388,8 @@ class Patvs_Fuction:
         return fernet.decrypt(encrypted_data).decode()
 
     def load_session_state(self):
-        if os.path.exists(self.TEMP_FILE):
-            with open(self.TEMP_FILE, "rb") as file:
+        if self.TEMP_FILE.exists():
+            with self.TEMP_FILE.open("rb") as file:
                 encrypted_data = file.read()
                 decrypted_data = self.decrypt_data(encrypted_data)
                 data = json.loads(decrypted_data)
@@ -425,13 +425,13 @@ class Patvs_Fuction:
             }
         )
         encrypted_data = self.encrypt_data(data)
-        with open(self.TEMP_FILE, "wb") as file:
+        with self.TEMP_FILE.open("wb") as file:
             file.write(encrypted_data)
 
     @classmethod
     def remove_temp_file(cls):
-        if os.path.exists(cls.TEMP_FILE):
-            os.remove(cls.TEMP_FILE)
+        if cls.TEMP_FILE.exists():
+            cls.TEMP_FILE.unlink(missing_ok=True)
 
     def normalize_action(self, action):
         return action.lower().replace(" ", "")

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -23,6 +23,7 @@ from monitoring.parser import MonitoringAction, parse_keywords, require_attachme
 from services.api_client import ApiClient, encode_attachment
 from ui.state import WindowStateStore
 from utils.exceptions import AuthenticationError, ClientError, ValidationError
+from config.settings import SETTINGS
 
 
 STATUS_COLORS = {
@@ -229,7 +230,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._pending_selection: Optional[Tuple[int, Optional[int], Optional[int], bool]] = None
         self._auto_start_in_progress = False
 
-        self._state_file_path = self._resolve_state_path()
+        self._state_file_path = SETTINGS.ui_state_file
         self._restore_department_id: Optional[int] = None
         self._restore_project_id: Optional[int] = None
         self._restore_plan_id: Optional[int] = None
@@ -729,13 +730,6 @@ class MainWindow(QtWidgets.QMainWindow):
         if state:
             self.restoreState(state)
 
-    def _resolve_state_path(self) -> str:
-        if os.name == "nt":
-            base_dir = r"C:\\PATVS"
-        else:
-            base_dir = os.path.join(os.path.expanduser("~"), "PATVS")
-        return os.path.join(base_dir, "window_state.json")
-
     def _state_username(self) -> str:
         if not isinstance(self._user, dict):
             return ""
@@ -759,14 +753,14 @@ class MainWindow(QtWidgets.QMainWindow):
         if not username:
             return {}
         try:
-            with open(self._state_file_path, "r", encoding="utf-8") as state_file:
+            with self._state_file_path.open("r", encoding="utf-8") as state_file:
                 payload = json.load(state_file)
         except FileNotFoundError:
             return {}
         except Exception as exc:  # pragma: no cover - defensive cleanup
             self._logger.error("读取状态文件失败: %s", exc)
             try:
-                os.remove(self._state_file_path)
+                self._state_file_path.unlink(missing_ok=True)
             except OSError:
                 pass
             return {}
@@ -844,10 +838,8 @@ class MainWindow(QtWidgets.QMainWindow):
             state["selection"] = [selection[0], selection[1], selection[2], selection[3]]
 
         try:
-            directory = os.path.dirname(self._state_file_path)
-            if directory:
-                os.makedirs(directory, exist_ok=True)
-            with open(self._state_file_path, "w", encoding="utf-8") as state_file:
+            self._state_file_path.parent.mkdir(parents=True, exist_ok=True)
+            with self._state_file_path.open("w", encoding="utf-8") as state_file:
                 json.dump(state, state_file, ensure_ascii=False, indent=2)
         except OSError as exc:  # pragma: no cover - file IO errors are non-fatal
             self._logger.warning("保存状态失败: %s", exc)


### PR DESCRIPTION
## Summary
- add dedicated config settings for UI state persistence and monitoring temp storage
- update main window and monitoring modules to use the centralized config paths
- derive monitoring log defaults from the shared config root

## Testing
- python -m compileall config monitoring ui

------
https://chatgpt.com/codex/tasks/task_b_690817d93ab88320b83d9e17f381f170