### PR TITLE
Fix power plug monitor remaining count updates

### DIFF
--- a/monitoring/actions/power_plug_monitor.py
+++ b/monitoring/actions/power_plug_monitor.py
@@ -36,6 +36,7 @@ def run(
                 if not plugged_in:
                     plug_unplug_cycles += 1
                     context.log(f"电源插拔完成次数: {plug_unplug_cycles}")
+                    context._record_count_progress(target_cycles, plug_unplug_cycles)
                     if plug_unplug_cycles >= target_cycles:
                         context.log(
                             f"已完成目标插拔次数:{plug_unplug_cycles} ，Exiting...."


### PR DESCRIPTION
## Summary
- update the power plug monitor to record completed cycles while monitoring
- ensure the remaining count for the current action reaches zero when the target is met so status logs are accurate

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_690820eca7888320a7882e7bd936f82c