### PR TITLE
Fix monitoring progress reporting and USB logging

### DIFF
--- a/monitoring/actions/audio_event_monitor.py
+++ b/monitoring/actions/audio_event_monitor.py
@@ -25,6 +25,7 @@ def run(context: "Patvs_Fuction", action_key: str, target_count: float, display_
         keyword = AUDIO_EVENT_KEYWORDS[action_key]
         target_count_int = int(float(target_count)) if target_count is not None else 0
         target_count_int = max(0, target_count_int)
+        expected_keys = {display_action or action_key, action_key}
         if target_count_int == 0:
             context.log(
                 f"音频事件 {display_action or action_key} 目标次数为 0，自动跳过。"
@@ -41,6 +42,9 @@ def run(context: "Patvs_Fuction", action_key: str, target_count: float, display_
         if current_count >= target_count_int:
             context.log(
                 f"音频事件 {display_action or action_key} 已提前满足目标次数 {target_count_int}，当前计数 {current_count}。"
+            )
+            context.record_count_progress_if_current(
+                target_count_int, current_count, expected_keys=expected_keys
             )
             return
 
@@ -86,6 +90,11 @@ def run(context: "Patvs_Fuction", action_key: str, target_count: float, display_
                                 context.log(
                                     f"[{os.path.basename(path)}] 检测到 {keyword} ({current_count}/{target_count_int})"
                                 )
+                                context.record_count_progress_if_current(
+                                    target_count_int,
+                                    current_count,
+                                    expected_keys=expected_keys,
+                                )
                     line = file_obj.readline()
                 context.audio_log_offsets[path] = file_obj.tell()
                 if current_count >= target_count_int or not context.is_running:
@@ -99,9 +108,15 @@ def run(context: "Patvs_Fuction", action_key: str, target_count: float, display_
             context.log(
                 f"音频事件 {display_action or action_key} 已达到目标次数 {target_count_int}。"
             )
+            context.record_count_progress_if_current(
+                target_count_int, current_count, expected_keys=expected_keys
+            )
         else:
             context.log(
                 f"音频事件 {display_action or action_key} 监控结束，当前计数 {current_count}/{target_count_int}。"
+            )
+            context.record_count_progress_if_current(
+                target_count_int, current_count, expected_keys=expected_keys
             )
     except Exception as error:  # pragma: no cover - 兼容异常场景
         context.logger.error(

--- a/monitoring/actions/camera_monitor.py
+++ b/monitoring/actions/camera_monitor.py
@@ -16,6 +16,7 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
     cycle_count = 0
     last_camera_state = None
     cycle_started = False
+    expected_keys = {"摄像头", "camera"}
 
     while context.is_running and cycle_count < target_cycles:
         cap = cv2.VideoCapture(0)
@@ -31,6 +32,9 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
                 cycle_count += 1
                 cycle_started = False
                 context.log(f"检测到摄像头可以调用，完成一个开关周期！当前周期数：{cycle_count}")
+                context.record_count_progress_if_current(
+                    target_cycles, cycle_count, expected_keys=expected_keys
+                )
 
         last_camera_state = current_camera_state
         if cycle_count >= target_cycles:
@@ -38,5 +42,8 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
             break
         time.sleep(1)
 
+    context.record_count_progress_if_current(
+        target_cycles, cycle_count, expected_keys=expected_keys
+    )
     context.log("退出摄像头开关事件监控。")
     context.action_complete.set()

--- a/monitoring/actions/display_monitor.py
+++ b/monitoring/actions/display_monitor.py
@@ -16,6 +16,7 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
     previous_brightness = None
     off_cycle_count = 0
     was_display_on = True
+    expected_keys = {"显示器"}
 
     while context.is_running and off_cycle_count < target_cycles:
         try:
@@ -33,13 +34,21 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
             if was_display_on and previous_brightness:
                 off_cycle_count += 1
                 context.log(f"显示器关闭周期完成: {off_cycle_count} 次")
+                context.record_count_progress_if_current(
+                    target_cycles, off_cycle_count, expected_keys=expected_keys
+                )
             was_display_on = False
             previous_brightness = None
 
         time.sleep(5)
 
     if context.is_running:
-        context.log("显示器开关次数已达到目标次数，退出监控。")
+        context.record_count_progress_if_current(
+            target_cycles, off_cycle_count, expected_keys=expected_keys
+        )
+        context.log(
+            f"显示器开关次数已达到目标次数 ({target_cycles:g})，总计完成 {off_cycle_count} 次，退出监控。"
+        )
     else:
         context.log("退出显示器开关监控。")
     context.action_complete.set()

--- a/monitoring/actions/keyboard_any_monitor.py
+++ b/monitoring/actions/keyboard_any_monitor.py
@@ -21,6 +21,9 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
         nonlocal key_count
         key_count += 1
         context.log(f"Key pressed: {pressed_key}. Total count: {key_count}")
+        context.record_count_progress_if_current(
+            target_cycles, key_count, expected_keys={"键盘按键"}
+        )
         if key_count >= target_cycles:
             context.log("检测到已完成目标键盘按键次数. Exiting...")
             listener_stopped.set()
@@ -42,4 +45,7 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
             stop_thread.join()
     finally:
         context.log("停止键盘按键监控")
+        context.record_count_progress_if_current(
+            target_cycles, key_count, expected_keys={"键盘按键"}
+        )
         context.action_complete.set()

--- a/monitoring/actions/keyboard_specific_monitor.py
+++ b/monitoring/actions/keyboard_specific_monitor.py
@@ -17,12 +17,16 @@ def run(context: "Patvs_Fuction", target_cycles: float, key_name: Optional[str] 
     key_count = 0
     key = context.KEY_MAPPING.get(key_name.lower()) if key_name else None
     listener_stopped = threading.Event()
+    expected_keys = {key_name} if key_name else {"键盘按键"}
 
     def on_press(pressed_key):
         nonlocal key_count
         if key is None or pressed_key == key:
             key_count += 1
             context.log(f"Key pressed: {pressed_key}. Total count: {key_count}")
+            context.record_count_progress_if_current(
+                target_cycles, key_count, expected_keys=expected_keys
+            )
         if key_count >= target_cycles:
             context.log("Reached target keystroke count. Exiting...")
             listener_stopped.set()
@@ -44,4 +48,7 @@ def run(context: "Patvs_Fuction", target_cycles: float, key_name: Optional[str] 
             stop_thread.join()
     finally:
         context.log("Stopped monitoring keystrokes.")
+        context.record_count_progress_if_current(
+            target_cycles, key_count, expected_keys=expected_keys
+        )
         context.action_complete.set()

--- a/monitoring/actions/lock_screen_monitor.py
+++ b/monitoring/actions/lock_screen_monitor.py
@@ -12,5 +12,5 @@ if TYPE_CHECKING:  # pragma: no cover
 def run(context: "Patvs_Fuction", target_cycles: float) -> None:
     """启动锁屏监控。"""
 
-    monitor_locks(target_cycles, context.window)
+    monitor_locks(context, target_cycles)
     context.action_complete.set()

--- a/monitoring/actions/mouse_monitor.py
+++ b/monitoring/actions/mouse_monitor.py
@@ -16,6 +16,7 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
 
     click_count = 0
     listener_stopped = threading.Event()
+    expected_keys = {"鼠标点击"}
 
     def on_click(x, y, button, pressed):
         nonlocal click_count
@@ -23,6 +24,9 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
             click_count += 1
             context.log(
                 f"Mouse clicked at ({x}, {y}) with {button}. Total count: {click_count}"
+            )
+            context.record_count_progress_if_current(
+                target_cycles, click_count, expected_keys=expected_keys
             )
             if click_count >= target_cycles:
                 context.log("已完成目标点击次数. Exiting...")
@@ -45,4 +49,7 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
             stop_thread.join()
     finally:
         context.log("停止鼠标点击事件监控")
+        context.record_count_progress_if_current(
+            target_cycles, click_count, expected_keys=expected_keys
+        )
         context.action_complete.set()

--- a/monitoring/actions/usb_monitor.py
+++ b/monitoring/actions/usb_monitor.py
@@ -17,7 +17,7 @@ def run(
 ) -> None:
     """监控 USB 插拔事件。"""
 
-    notification = Notification(0, target_cycles, context.window)
+    notification = Notification(context, 0, target_cycles)
     try:
         notification.messageLoop()
     finally:

--- a/monitoring/actions/volume_monitor.py
+++ b/monitoring/actions/volume_monitor.py
@@ -27,6 +27,7 @@ def run(context: "Patvs_Fuction", target_change_count: float) -> None:
     previous_volume = _get_volume()
     change_count = 0
     context.log(f"初始系统音量: {previous_volume * 100:.2f}%")
+    expected_keys = {"音量"}
 
     while context.is_running and change_count < target_change_count:
         time.sleep(1)
@@ -37,9 +38,17 @@ def run(context: "Patvs_Fuction", target_change_count: float) -> None:
                 f"音量变化次数: {change_count}, 当前音量: {current_volume * 100:.2f}%"
             )
             previous_volume = current_volume
+            context.record_count_progress_if_current(
+                target_change_count, change_count, expected_keys=expected_keys
+            )
 
     if context.is_running:
-        context.log("音量变化次数已达到目标次数，退出监控。")
+        context.record_count_progress_if_current(
+            target_change_count, change_count, expected_keys=expected_keys
+        )
+        context.log(
+            f"音量变化次数已达到目标次数 ({target_change_count:g})，总计完成 {change_count} 次，退出监控。"
+        )
     else:
         context.log("退出音量加减事件监控。")
     context.action_complete.set()

--- a/monitoring/devicerm.py
+++ b/monitoring/devicerm.py
@@ -27,15 +27,20 @@ import uuid
 GUID_DEVINTERFACE_USB_DEVICE = "{A5DCBF10-6530-11D2-901F-00C04FB951ED}"
 
 class Notification:
-    def __init__(self, cycles_count, target_cycles, window):
+    def __init__(self, context, cycles_count, target_cycles):
+        self.context = context
         self.cycles_count = cycles_count   # 初始化插拔次数
         self.target_cycles = target_cycles  # 目标的插拔次数
-        self.window = window
+        self.window = context.window
         self.hwnd = None
         self.hdn = None
         self.class_name = f"DeviceChange_WindowClass_{uuid.uuid4()}"
         self.init_notification_window()
-        logger.info(f"Initialized Notification with cycles_count: {self.cycles_count}, target_cycles: {self.target_cycles}")
+        logger.info(
+            "Initialized Notification with cycles_count: %s, target_cycles: %s",
+            self.cycles_count,
+            self.target_cycles,
+        )
 
     def init_notification_window(self):
         message_map = {win32con.WM_DEVICECHANGE: self.onDeviceChange}
@@ -70,14 +75,27 @@ class Notification:
         dbch = win32gui_struct.UnpackDEV_BROADCAST(lparam)
         if wparam == win32con.DBT_DEVICEREMOVECOMPLETE:
             self.cycles_count += 1
-            message = f"Device {dbch.name} removed, current count: {self.cycles_count}"
-            wx.CallAfter(self.window.add_log_message, message)
+            self.context.log(
+                f"检测到 USB 设备移除: {dbch.name}，当前插拔次数: {self.cycles_count}"
+            )
+            self.context.record_count_progress_if_current(
+                self.target_cycles,
+                self.cycles_count,
+                expected_keys={"usb插拔", "s3插拔"},
+            )
         elif wparam == win32con.DBT_DEVICEARRIVAL:
-            message = f"Device {dbch.name} arrived, current count: {self.cycles_count}"
-            wx.CallAfter(self.window.add_log_message, message)
+            self.context.log(
+                f"检测到 USB 设备接入: {dbch.name}，当前插拔次数: {self.cycles_count}"
+            )
         if self.cycles_count >= self.target_cycles:
-            message = f"检测到已完成设备插拔目标次数: {self.cycles_count}"
-            wx.CallAfter(self.window.add_log_message, message)
+            self.context.record_count_progress_if_current(
+                self.target_cycles,
+                self.cycles_count,
+                expected_keys={"usb插拔", "s3插拔"},
+            )
+            self.context.log(
+                f"USB 插拔任务已完成 {self.cycles_count} 次，目标次数为 {self.target_cycles} 次。"
+            )
             win32gui.PostQuitMessage(0)
 
         return 1

--- a/monitoring/lock_screen.py
+++ b/monitoring/lock_screen.py
@@ -8,8 +8,13 @@ import win32ts
 import uuid
 from PyQt5 import QtCore
 import logging
+from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .patvs_monitor import Patvs_Fuction
 
 
 class _WxCompat:
@@ -33,9 +38,10 @@ class WTSSESSION_NOTIFICATION(ctypes.Structure):
 
 
 class SessionNotificationHandler:
-    def __init__(self, target_cycles, window):
+    def __init__(self, context: "Patvs_Fuction", target_cycles):
         self.hwnd = None
-        self.window = window
+        self.context = context
+        self.window = context.window
         self.className = f"suopin_WindowClass_{uuid.uuid4()}"
         self.target_cycles = target_cycles
         self.lock_count = 0
@@ -54,10 +60,19 @@ class SessionNotificationHandler:
         if msg == WM_WTSSESSION_CHANGE:  # 使用自定义的常量
             if wparam == WTS_SESSION_LOCK:
                 self.lock_count += 1
-                wx.CallAfter(self.window.add_log_message, f"会话已锁定. 锁屏次数: {self.lock_count}")
+                self.context.log(f"会话已锁定. 锁屏次数: {self.lock_count}")
+                self.context.record_count_progress_if_current(
+                    self.target_cycles, self.lock_count, expected_keys={"锁屏"}
+                )
                 if self.lock_count >= self.target_cycles:
-                    wx.CallAfter(self.window.add_log_message,
-                                 f"已完成目标锁屏次数: {self.target_cycles} ，Exiting...")
+                    self.context.record_count_progress_if_current(
+                        self.target_cycles,
+                        self.lock_count,
+                        expected_keys={"锁屏"},
+                    )
+                    self.context.log(
+                        f"已完成目标锁屏次数: {self.target_cycles} ，Exiting..."
+                    )
                     win32ts.WTSUnRegisterSessionNotification(self.hwnd)
                     win32gui.DestroyWindow(self.hwnd)
                     win32gui.PostQuitMessage(0)
@@ -67,11 +82,11 @@ class SessionNotificationHandler:
         return win32gui.DefWindowProc(hwnd, msg, wparam, lparam)
 
     def run(self):
-        wx.CallAfter(self.window.add_log_message, "开始监控电脑锁屏事件")
+        self.context.log("开始监控电脑锁屏事件")
         try:
             win32gui.PumpMessages()
         except KeyboardInterrupt:
-            wx.CallAfter(self.window.add_log_message, "停止电脑锁屏监控.......")
+            self.context.log("停止电脑锁屏监控.......")
             win32ts.WTSUnRegisterSessionNotification(self.hwnd)
             win32gui.DestroyWindow(self.hwnd)
             win32gui.UnregisterClass(self.class_atom, None)
@@ -79,6 +94,6 @@ class SessionNotificationHandler:
             logger.error(f"未知错误 {e}")
 
 
-def monitor_locks(target_cycles, window):
-    handler = SessionNotificationHandler(target_cycles, window)
+def monitor_locks(context: "Patvs_Fuction", target_cycles):
+    handler = SessionNotificationHandler(context, target_cycles)
     handler.run()

--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -278,6 +278,25 @@ class Patvs_Fuction:
             remaining = 0.0
         self._update_current_action_remaining(max(0.0, remaining))
 
+    def record_count_progress_if_current(self, target, completed, expected_keys=None):
+        """更新当前动作的次数进度，避免串扰其他动作。"""
+
+        normalized_expected = None
+        if expected_keys:
+            normalized_expected = {
+                self.normalize_action(key)
+                for key in expected_keys
+                if key is not None
+            }
+        with self.state_lock:
+            if not self.remaining_actions:
+                return
+            current_name = self.remaining_actions[0]["name"]
+        normalized_current = self.normalize_action(current_name)
+        if normalized_expected and normalized_current not in normalized_expected:
+            return
+        self._record_count_progress(target, completed, action_key=normalized_current)
+
     def _record_time_progress(self, remaining_seconds):
         with self.state_lock:
             current_name = (


### PR DESCRIPTION
## Summary
- ensure the USB monitor logs plug/unplug activity and records progress through the context helper
- add a `record_count_progress_if_current` helper to avoid cross-action updates and apply it across keyboard, mouse, display, volume, audio, camera, and lock screen monitors
- align lock screen monitoring with the context logger so completion messages and progress tracking are correct

## Testing
- python -m compileall monitoring

------
https://chatgpt.com/codex/tasks/task_b_6908230ef6488320b0ea02bcc529f8d5