### PR TITLE
Fix monitor resume counts for hardware actions

### DIFF
--- a/monitoring/actions/camera_monitor.py
+++ b/monitoring/actions/camera_monitor.py
@@ -10,15 +10,46 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", target_cycles: float) -> None:
-    """检测摄像头被占用与释放的周期次数。"""
+def run(
+    context: "Patvs_Fuction",
+    target_cycles: float,
+    remaining_cycles: float | None = None,
+) -> None:
+    """检测摄像头被占用与释放的周期次数，支持断点续跑。"""
 
-    cycle_count = 0
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("摄像头开关目标次数为 0，自动跳过。")
+        context.record_count_progress_if_current(
+            0, 0, expected_keys={"摄像头", "camera"}
+        )
+        context.log("退出摄像头开关事件监控。")
+        context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
+
+    cycle_count = max(0.0, total_target - remaining)
     last_camera_state = None
     cycle_started = False
     expected_keys = {"摄像头", "camera"}
 
-    while context.is_running and cycle_count < target_cycles:
+    if cycle_count > 0:
+        context.log(
+            f"摄像头开关已累计 {cycle_count:g} 次，剩余 {max(0.0, total_target - cycle_count):g} 次。"
+        )
+
+    while context.is_running and cycle_count < total_target:
         cap = cv2.VideoCapture(0)
         ret, _ = cap.read()
         cap.release()
@@ -33,17 +64,17 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
                 cycle_started = False
                 context.log(f"检测到摄像头可以调用，完成一个开关周期！当前周期数：{cycle_count}")
                 context.record_count_progress_if_current(
-                    target_cycles, cycle_count, expected_keys=expected_keys
+                    total_target, cycle_count, expected_keys=expected_keys
                 )
 
         last_camera_state = current_camera_state
-        if cycle_count >= target_cycles:
-            context.log(f"摄像头开关周期数已达到目标值 ({target_cycles})，退出检测。")
+        if cycle_count >= total_target:
+            context.log(f"摄像头开关周期数已达到目标值 ({total_target})，退出检测。")
             break
         time.sleep(1)
 
     context.record_count_progress_if_current(
-        target_cycles, cycle_count, expected_keys=expected_keys
+        total_target, cycle_count, expected_keys=expected_keys
     )
     context.log("退出摄像头开关事件监控。")
     context.action_complete.set()

--- a/monitoring/actions/display_monitor.py
+++ b/monitoring/actions/display_monitor.py
@@ -10,15 +10,42 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", target_cycles: float) -> None:
-    """检测显示器亮度变化，统计关闭周期。"""
+def run(
+    context: "Patvs_Fuction",
+    target_cycles: float,
+    remaining_cycles: float | None = None,
+) -> None:
+    """检测显示器亮度变化，统计关闭周期，支持断点续跑。"""
+
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("显示器开关目标次数为 0，自动跳过。")
+        context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
 
     previous_brightness = None
-    off_cycle_count = 0
+    off_cycle_count = max(0.0, total_target - remaining)
     was_display_on = True
     expected_keys = {"显示器"}
 
-    while context.is_running and off_cycle_count < target_cycles:
+    if off_cycle_count > 0:
+        context.log(
+            f"显示器开关已累计完成 {off_cycle_count:g} 次，剩余 {max(0.0, total_target - off_cycle_count):g} 次。"
+        )
+
+    while context.is_running and off_cycle_count < total_target:
         try:
             current_brightness = sbc.get_brightness(display=0)
             context.log(f"当前显示器亮度: {current_brightness}")
@@ -35,7 +62,7 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
                 off_cycle_count += 1
                 context.log(f"显示器关闭周期完成: {off_cycle_count} 次")
                 context.record_count_progress_if_current(
-                    target_cycles, off_cycle_count, expected_keys=expected_keys
+                    total_target, off_cycle_count, expected_keys=expected_keys
                 )
             was_display_on = False
             previous_brightness = None
@@ -44,10 +71,10 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
 
     if context.is_running:
         context.record_count_progress_if_current(
-            target_cycles, off_cycle_count, expected_keys=expected_keys
+            total_target, off_cycle_count, expected_keys=expected_keys
         )
         context.log(
-            f"显示器开关次数已达到目标次数 ({target_cycles:g})，总计完成 {off_cycle_count} 次，退出监控。"
+            f"显示器开关次数已达到目标次数 ({total_target:g})，总计完成 {off_cycle_count} 次，退出监控。"
         )
     else:
         context.log("退出显示器开关监控。")

--- a/monitoring/actions/keyboard_any_monitor.py
+++ b/monitoring/actions/keyboard_any_monitor.py
@@ -11,20 +11,47 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", target_cycles: float) -> None:
-    """监听任意按键，达到目标次数后退出。"""
+def run(
+    context: "Patvs_Fuction",
+    target_cycles: float,
+    remaining_cycles: float | None = None,
+) -> None:
+    """监听任意按键，达到目标次数后退出，支持断点续跑。"""
 
-    key_count = 0
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("键盘按键目标次数为 0，自动跳过。")
+        context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
+
+    key_count = max(0.0, total_target - remaining)
     listener_stopped = threading.Event()
+
+    if key_count > 0:
+        context.log(
+            f"键盘按键已累计 {key_count:g} 次，剩余 {max(0.0, total_target - key_count):g} 次。"
+        )
 
     def on_press(pressed_key):
         nonlocal key_count
         key_count += 1
         context.log(f"Key pressed: {pressed_key}. Total count: {key_count}")
         context.record_count_progress_if_current(
-            target_cycles, key_count, expected_keys={"键盘按键"}
+            total_target, key_count, expected_keys={"键盘按键"}
         )
-        if key_count >= target_cycles:
+        if key_count >= total_target:
             context.log("检测到已完成目标键盘按键次数. Exiting...")
             listener_stopped.set()
             return False
@@ -46,6 +73,6 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
     finally:
         context.log("停止键盘按键监控")
         context.record_count_progress_if_current(
-            target_cycles, key_count, expected_keys={"键盘按键"}
+            total_target, key_count, expected_keys={"键盘按键"}
         )
         context.action_complete.set()

--- a/monitoring/actions/keyboard_specific_monitor.py
+++ b/monitoring/actions/keyboard_specific_monitor.py
@@ -11,13 +11,41 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", target_cycles: float, key_name: Optional[str] = None) -> None:
-    """监听特定按键，达到目标次数后退出。"""
+def run(
+    context: "Patvs_Fuction",
+    target_cycles: float,
+    key_name: Optional[str] = None,
+    remaining_cycles: float | None = None,
+) -> None:
+    """监听特定按键，达到目标次数后退出，支持断点续跑。"""
 
-    key_count = 0
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("特定键监控目标次数为 0，自动跳过。")
+        context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
+
+    key_count = max(0.0, total_target - remaining)
     key = context.KEY_MAPPING.get(key_name.lower()) if key_name else None
     listener_stopped = threading.Event()
     expected_keys = {key_name} if key_name else {"键盘按键"}
+
+    if key_count > 0:
+        context.log(
+            f"{key_name or '键盘按键'} 已累计 {key_count:g} 次，剩余 {max(0.0, total_target - key_count):g} 次。"
+        )
 
     def on_press(pressed_key):
         nonlocal key_count
@@ -25,9 +53,9 @@ def run(context: "Patvs_Fuction", target_cycles: float, key_name: Optional[str] 
             key_count += 1
             context.log(f"Key pressed: {pressed_key}. Total count: {key_count}")
             context.record_count_progress_if_current(
-                target_cycles, key_count, expected_keys=expected_keys
+                total_target, key_count, expected_keys=expected_keys
             )
-        if key_count >= target_cycles:
+        if key_count >= total_target:
             context.log("Reached target keystroke count. Exiting...")
             listener_stopped.set()
             return False
@@ -49,6 +77,6 @@ def run(context: "Patvs_Fuction", target_cycles: float, key_name: Optional[str] 
     finally:
         context.log("Stopped monitoring keystrokes.")
         context.record_count_progress_if_current(
-            target_cycles, key_count, expected_keys=expected_keys
+            total_target, key_count, expected_keys=expected_keys
         )
         context.action_complete.set()

--- a/monitoring/actions/lock_screen_monitor.py
+++ b/monitoring/actions/lock_screen_monitor.py
@@ -9,8 +9,12 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", target_cycles: float) -> None:
-    """启动锁屏监控。"""
+def run(
+    context: "Patvs_Fuction",
+    target_cycles: float,
+    remaining_cycles: float | None = None,
+) -> None:
+    """启动锁屏监控，支持断点续跑。"""
 
-    monitor_locks(context, target_cycles)
+    monitor_locks(context, target_cycles, remaining_cycles=remaining_cycles)
     context.action_complete.set()

--- a/monitoring/actions/mouse_monitor.py
+++ b/monitoring/actions/mouse_monitor.py
@@ -11,12 +11,39 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", target_cycles: float) -> None:
-    """监听鼠标点击事件，完成既定次数后退出。"""
+def run(
+    context: "Patvs_Fuction",
+    target_cycles: float,
+    remaining_cycles: float | None = None,
+) -> None:
+    """监听鼠标点击事件，完成既定次数后退出，支持断点续跑。"""
 
-    click_count = 0
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("鼠标点击目标次数为 0，自动跳过。")
+        context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
+
+    click_count = max(0.0, total_target - remaining)
     listener_stopped = threading.Event()
     expected_keys = {"鼠标点击"}
+
+    if click_count > 0:
+        context.log(
+            f"鼠标点击已累计 {click_count:g} 次，剩余 {max(0.0, total_target - click_count):g} 次。"
+        )
 
     def on_click(x, y, button, pressed):
         nonlocal click_count
@@ -26,9 +53,9 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
                 f"Mouse clicked at ({x}, {y}) with {button}. Total count: {click_count}"
             )
             context.record_count_progress_if_current(
-                target_cycles, click_count, expected_keys=expected_keys
+                total_target, click_count, expected_keys=expected_keys
             )
-            if click_count >= target_cycles:
+            if click_count >= total_target:
                 context.log("已完成目标点击次数. Exiting...")
                 listener_stopped.set()
                 return False
@@ -50,6 +77,6 @@ def run(context: "Patvs_Fuction", target_cycles: float) -> None:
     finally:
         context.log("停止鼠标点击事件监控")
         context.record_count_progress_if_current(
-            target_cycles, click_count, expected_keys=expected_keys
+            total_target, click_count, expected_keys=expected_keys
         )
         context.action_complete.set()

--- a/monitoring/actions/power_plug_monitor.py
+++ b/monitoring/actions/power_plug_monitor.py
@@ -15,13 +15,40 @@ def run(
     context: "Patvs_Fuction",
     target_cycles: float,
     power_done_event: Optional[threading.Event] = None,
+    *,
+    remaining_cycles: float | None = None,
 ) -> None:
-    """监控电源插拔次数。"""
+    """监控电源插拔次数，支持断点续跑。"""
+
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("电源插拔目标次数为 0，自动跳过。")
+        if power_done_event:
+            power_done_event.set()
+        else:
+            context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
 
     plugged_in_last_state = None
-    plug_unplug_cycles = 0
+    plug_unplug_cycles = max(0.0, total_target - remaining)
+    if plug_unplug_cycles > 0:
+        context.log(
+            f"电源插拔已累计 {plug_unplug_cycles:g} 次，剩余 {max(0.0, total_target - plug_unplug_cycles):g} 次。"
+        )
     try:
-        while context.is_running and plug_unplug_cycles < target_cycles:
+        while context.is_running and plug_unplug_cycles < total_target:
             battery = psutil.sensors_battery()
             if not battery:
                 context.logger.error("No battery information found")
@@ -36,8 +63,8 @@ def run(
                 if not plugged_in:
                     plug_unplug_cycles += 1
                     context.log(f"电源插拔完成次数: {plug_unplug_cycles}")
-                    context._record_count_progress(target_cycles, plug_unplug_cycles)
-                    if plug_unplug_cycles >= target_cycles:
+                    context._record_count_progress(total_target, plug_unplug_cycles)
+                    if plug_unplug_cycles >= total_target:
                         context.log(
                             f"已完成目标插拔次数:{plug_unplug_cycles} ，Exiting...."
                         )

--- a/monitoring/actions/s3_power_cycle_monitor.py
+++ b/monitoring/actions/s3_power_cycle_monitor.py
@@ -10,11 +10,41 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", start_time, target_cycles) -> None:
-    """顺序执行 S3 睡眠与电源插拔动作。"""
+def run(
+    context: "Patvs_Fuction",
+    start_time,
+    target_cycles,
+    remaining_cycles: float | None = None,
+) -> None:
+    """顺序执行 S3 睡眠与电源插拔动作，支持断点续跑。"""
 
-    context.log(f"开始执行监控: S3电源插拔，目标测试次数: {target_cycles}")
-    for index in range(int(target_cycles)):
+    try:
+        total_target = int(float(target_cycles))
+    except (TypeError, ValueError):
+        total_target = 0
+
+    if total_target <= 0:
+        context.log("S3 电源插拔目标次数为 0，自动跳过。")
+        context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = float(total_target)
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = float(total_target)
+    remaining = max(0.0, min(float(total_target), remaining))
+    completed = int(max(0.0, float(total_target) - remaining))
+
+    context.log(f"开始执行监控: S3电源插拔，目标测试次数: {total_target}")
+    if completed > 0:
+        context.log(
+            f"S3 电源插拔已累计完成 {completed} 次，剩余 {max(0, total_target - completed)} 次。"
+        )
+
+    for index in range(completed, total_target):
         s3_done_event = threading.Event()
         s3_thread = threading.Thread(
             target=s3_sleep_monitor.run,
@@ -26,7 +56,8 @@ def run(context: "Patvs_Fuction", start_time, target_cycles) -> None:
 
         power_done_event = threading.Event()
         power_thread = threading.Thread(
-            target=power_plug_monitor.run, args=(context, 1, power_done_event)
+            target=power_plug_monitor.run,
+            args=(context, 1, power_done_event),
         )
         power_thread.start()
         power_done_event.wait()

--- a/monitoring/actions/s3_usb_cycle_monitor.py
+++ b/monitoring/actions/s3_usb_cycle_monitor.py
@@ -11,8 +11,32 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
-def run(context: "Patvs_Fuction", start_time, s3_target_cycles, usb_target_cycles) -> None:
-    """并行监控 S3 事件与 USB 插拔。"""
+def run(
+    context: "Patvs_Fuction",
+    start_time,
+    s3_target_cycles,
+    usb_target_cycles,
+    remaining_cycles: float | None = None,
+) -> None:
+    """并行监控 S3 事件与 USB 插拔，支持断点续跑。"""
+
+    try:
+        total_target = float(usb_target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if remaining_cycles is None:
+        remaining_usb = total_target
+    else:
+        try:
+            remaining_usb = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining_usb = total_target
+    remaining_usb = max(0.0, min(total_target, remaining_usb))
+    completed = max(0.0, total_target - remaining_usb)
+    if completed > 0:
+        context.log(
+            f"S3 + USB 插拔已累计完成 {completed:g} 次，剩余 {max(0.0, total_target - completed):g} 次。"
+        )
 
     s3_done_event = threading.Event()
     usb_done_event = threading.Event()
@@ -24,6 +48,7 @@ def run(context: "Patvs_Fuction", start_time, s3_target_cycles, usb_target_cycle
     usb_thread = threading.Thread(
         target=usb_monitor.run,
         args=(context, usb_target_cycles, usb_done_event),
+        kwargs={"remaining_cycles": remaining_usb},
     )
 
     s3_thread.start()

--- a/monitoring/actions/usb_monitor.py
+++ b/monitoring/actions/usb_monitor.py
@@ -14,10 +14,39 @@ def run(
     context: "Patvs_Fuction",
     target_cycles: float,
     usb_done_event: Optional[threading.Event] = None,
+    *,
+    remaining_cycles: float | None = None,
 ) -> None:
-    """监控 USB 插拔事件。"""
+    """监控 USB 插拔事件，支持断点续跑。"""
 
-    notification = Notification(context, 0, target_cycles)
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("USB 插拔目标次数为 0，自动跳过。")
+        if usb_done_event:
+            usb_done_event.set()
+        else:
+            context.action_complete.set()
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
+    completed = max(0.0, total_target - remaining)
+
+    if completed > 0:
+        context.log(
+            f"USB 插拔已累计 {completed:g} 次，剩余 {max(0.0, total_target - completed):g} 次。"
+        )
+
+    notification = Notification(context, completed, total_target)
     try:
         notification.messageLoop()
     finally:

--- a/monitoring/actions/volume_monitor.py
+++ b/monitoring/actions/volume_monitor.py
@@ -26,8 +26,31 @@ def _get_volume() -> float:
     return volume.GetMasterVolumeLevelScalar()
 
 
-def run(context: "Patvs_Fuction", target_change_count: float) -> None:
-    """监控系统音量变化次数。"""
+def run(
+    context: "Patvs_Fuction",
+    target_change_count: float,
+    remaining_change_count: float | None = None,
+) -> None:
+    """监控系统音量变化次数，支持断点续跑。"""
+
+    try:
+        total_target = float(target_change_count)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("音量目标次数为 0，自动跳过。")
+        context.action_complete.set()
+        return
+
+    if remaining_change_count is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_change_count)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
+    change_count = max(0.0, total_target - remaining)
 
     coinited = False
     if pythoncom is not None:
@@ -39,11 +62,15 @@ def run(context: "Patvs_Fuction", target_change_count: float) -> None:
 
     try:
         previous_volume = _get_volume()
-        change_count = 0
         context.log(f"初始系统音量: {previous_volume * 100:.2f}%")
+        if change_count > 0:
+            remaining_to_go = max(0.0, total_target - change_count)
+            context.log(
+                f"音量变化已累计 {change_count:g} 次，剩余 {remaining_to_go:g} 次。"
+            )
         expected_keys = {"音量"}
 
-        while context.is_running and change_count < target_change_count:
+        while context.is_running and change_count < total_target:
             time.sleep(1)
             current_volume = _get_volume()
             if current_volume != previous_volume:
@@ -53,15 +80,15 @@ def run(context: "Patvs_Fuction", target_change_count: float) -> None:
                 )
                 previous_volume = current_volume
                 context.record_count_progress_if_current(
-                    target_change_count, change_count, expected_keys=expected_keys
+                    total_target, change_count, expected_keys=expected_keys
                 )
 
         if context.is_running:
             context.record_count_progress_if_current(
-                target_change_count, change_count, expected_keys=expected_keys
+                total_target, change_count, expected_keys=expected_keys
             )
             context.log(
-                f"音量变化次数已达到目标次数 ({target_change_count:g})，总计完成 {change_count} 次，退出监控。"
+                f"音量变化次数已达到目标次数 ({total_target:g})，总计完成 {change_count} 次，退出监控。"
             )
         else:
             context.log("退出音量加减事件监控。")

--- a/monitoring/devicerm.py
+++ b/monitoring/devicerm.py
@@ -29,8 +29,14 @@ GUID_DEVINTERFACE_USB_DEVICE = "{A5DCBF10-6530-11D2-901F-00C04FB951ED}"
 class Notification:
     def __init__(self, context, cycles_count, target_cycles):
         self.context = context
-        self.cycles_count = cycles_count   # 初始化插拔次数
-        self.target_cycles = target_cycles  # 目标的插拔次数
+        try:
+            self.cycles_count = int(float(cycles_count))
+        except (TypeError, ValueError):
+            self.cycles_count = 0
+        try:
+            self.target_cycles = float(target_cycles)
+        except (TypeError, ValueError):
+            self.target_cycles = 0.0
         self.window = context.window
         self.hwnd = None
         self.hdn = None
@@ -87,7 +93,7 @@ class Notification:
             self.context.log(
                 f"检测到 USB 设备接入: {dbch.name}，当前插拔次数: {self.cycles_count}"
             )
-        if self.cycles_count >= self.target_cycles:
+        if self.target_cycles and self.cycles_count >= self.target_cycles:
             self.context.record_count_progress_if_current(
                 self.target_cycles,
                 self.cycles_count,

--- a/monitoring/lock_screen.py
+++ b/monitoring/lock_screen.py
@@ -38,13 +38,16 @@ class WTSSESSION_NOTIFICATION(ctypes.Structure):
 
 
 class SessionNotificationHandler:
-    def __init__(self, context: "Patvs_Fuction", target_cycles):
+    def __init__(self, context: "Patvs_Fuction", target_cycles, initial_count=0):
         self.hwnd = None
         self.context = context
         self.window = context.window
         self.className = f"suopin_WindowClass_{uuid.uuid4()}"
         self.target_cycles = target_cycles
-        self.lock_count = 0
+        try:
+            self.lock_count = int(float(initial_count))
+        except (TypeError, ValueError):
+            self.lock_count = 0
         wc = win32gui.WNDCLASS()
         wc.lpfnWndProc = self.wnd_proc
         wc.lpszClassName = self.className
@@ -64,7 +67,7 @@ class SessionNotificationHandler:
                 self.context.record_count_progress_if_current(
                     self.target_cycles, self.lock_count, expected_keys={"锁屏"}
                 )
-                if self.lock_count >= self.target_cycles:
+                if self.target_cycles and self.lock_count >= self.target_cycles:
                     self.context.record_count_progress_if_current(
                         self.target_cycles,
                         self.lock_count,
@@ -94,6 +97,30 @@ class SessionNotificationHandler:
             logger.error(f"未知错误 {e}")
 
 
-def monitor_locks(context: "Patvs_Fuction", target_cycles):
-    handler = SessionNotificationHandler(context, target_cycles)
+def monitor_locks(context: "Patvs_Fuction", target_cycles, remaining_cycles=None):
+    try:
+        total_target = float(target_cycles)
+    except (TypeError, ValueError):
+        total_target = 0.0
+    if total_target <= 0:
+        context.log("锁屏目标次数为 0，自动跳过。")
+        context.record_count_progress_if_current(0, 0, expected_keys={"锁屏"})
+        return
+
+    if remaining_cycles is None:
+        remaining = total_target
+    else:
+        try:
+            remaining = float(remaining_cycles)
+        except (TypeError, ValueError):
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
+    completed = max(0.0, total_target - remaining)
+
+    if completed > 0:
+        context.log(
+            f"锁屏已累计 {completed:g} 次，剩余 {max(0.0, total_target - completed):g} 次。"
+        )
+
+    handler = SessionNotificationHandler(context, total_target, initial_count=completed)
     handler.run()

--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -583,6 +583,14 @@ class Patvs_Fuction:
                 unit = current_action.get("unit", "count")
                 target_value = current_action.get("target", 0)
                 remaining_value = current_action.get("remaining", target_value)
+                try:
+                    target_value_float = float(target_value)
+                except (TypeError, ValueError):
+                    target_value_float = 0.0
+                try:
+                    remaining_value_float = float(remaining_value)
+                except (TypeError, ValueError):
+                    remaining_value_float = target_value_float
                 if self.is_running:
                     display_action = action
                     normalized_action = self.normalize_action(action)
@@ -604,14 +612,18 @@ class Patvs_Fuction:
                             f"开始执行监控: {action}，目标测试次数: {target_value:g}"
                         )
                         threading.Thread(
-                            target=power_plug_monitor.run, args=(self, target_value)
+                            target=power_plug_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action.lower() == "usb插拔":
                         self.log(
                             f"开始执行监控: {action}，目标测试次数: {target_value:g}"
                         )
                         thread = threading.Thread(
-                            target=usb_monitor.run, args=(self, target_value)
+                            target=usb_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         )
                         thread.start()
                         self.msg_loop_thread_id = thread.ident
@@ -620,14 +632,18 @@ class Patvs_Fuction:
                             f"开始执行监控: {action}，目标测试次数: {target_value:g}"
                         )
                         threading.Thread(
-                            target=keyboard_any_monitor.run, args=(self, target_value)
+                            target=keyboard_any_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action == "锁屏":
                         self.log(
                             f"开始执行监控: {action}，目标测试次数: {target_value:g}"
                         )
                         thread = threading.Thread(
-                            target=lock_screen_monitor.run, args=(self, target_value)
+                            target=lock_screen_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         )
                         thread.start()
                         self.msg_loop_thread_id = thread.ident
@@ -636,7 +652,9 @@ class Patvs_Fuction:
                             f"开始执行监控: {action}，目标测试次数: {target_value:g}"
                         )
                         threading.Thread(
-                            target=mouse_monitor.run, args=(self, target_value)
+                            target=mouse_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action == "s3":
                         self.log(
@@ -677,6 +695,7 @@ class Patvs_Fuction:
                         threading.Thread(
                             target=keyboard_specific_monitor.run,
                             args=(self, target_value, action),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action == "s3插拔":
                         self.log(
@@ -684,7 +703,13 @@ class Patvs_Fuction:
                         )
                         threading.Thread(
                             target=s3_usb_cycle_monitor.run,
-                            args=(self, self.case_start_time, target_value, target_value),
+                            args=(
+                                self,
+                                self.case_start_time,
+                                target_value,
+                                target_value,
+                            ),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action == "s3电源插拔":
                         self.log(
@@ -693,27 +718,34 @@ class Patvs_Fuction:
                         threading.Thread(
                             target=s3_power_cycle_monitor.run,
                             args=(self, self.case_start_time, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action == "显示器":
                         self.log(
                             f"开始执行监控: {action} 开关事件，目标测试次数: {target_value:g}"
                         )
                         threading.Thread(
-                            target=display_monitor.run, args=(self, target_value)
+                            target=display_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action == "音量":
                         self.log(
                             f"开始执行监控: {action} 加减事件，目标测试次数: {target_value:g}"
                         )
                         threading.Thread(
-                            target=volume_monitor.run, args=(self, target_value)
+                            target=volume_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_change_count": remaining_value_float},
                         ).start()
                     elif normalized_action in {"摄像头", "camera"}:
                         self.log(
                             f"开始执行监控: {action} 开关事件，目标测试次数: {target_value:g}"
                         )
                         threading.Thread(
-                            target=camera_monitor.run, args=(self, target_value)
+                            target=camera_monitor.run,
+                            args=(self, target_value),
+                            kwargs={"remaining_cycles": remaining_value_float},
                         ).start()
                     elif normalized_action in AUDIO_EVENT_KEYWORDS:
                         self.log(


### PR DESCRIPTION
## Summary
- ensure counter-based hardware monitors resume from saved remaining counts after restarting a session
- pass persisted progress through the PATVS dispatcher and USB notification helper so monitoring logs reflect accurate totals
- update combined S3 workflows to honour previously completed cycles before continuing

## Testing
- python -m compileall monitoring

------
https://chatgpt.com/codex/tasks/task_b_6908615e088483208aab163af4d43d04