### PR TITLE
Ensure monitoring stop unblocks waiting actions

### DIFF
--- a/monitoring/controller.py
+++ b/monitoring/controller.py
@@ -52,6 +52,8 @@ class MonitoringController(QtCore.QObject):
         if self._worker is None:
             return
         self._worker.is_running = False
+        # 确保当前等待的动作线程被唤醒，避免主调度卡在 action_complete.wait()
+        self._worker.action_complete.set()
 
     def start(self, case_id: int, actions: Sequence[Tuple[str, float]], start_time: str) -> None:
         if self.is_running():
@@ -86,3 +88,4 @@ class MonitoringController(QtCore.QObject):
             thread.join(timeout=0)
         if worker:
             worker.is_running = False
+            worker.action_complete.set()

--- a/monitoring/manager.py
+++ b/monitoring/manager.py
@@ -30,6 +30,8 @@ class MonitoringManager(QtCore.QObject):
         if self._worker is None:
             return
         self._worker.is_running = False
+        # 立即唤醒可能正在等待动作完成的主调度线程，避免阻塞
+        self._worker.action_complete.set()
 
     def discard_session_state(self) -> None:
         """Clear any persisted monitoring progress for the active worker."""
@@ -69,6 +71,7 @@ class MonitoringManager(QtCore.QObject):
         self._thread = None
         if worker:
             worker.is_running = False
+            worker.action_complete.set()
         if thread and thread is not threading.current_thread():
             thread.join(timeout=0)
         self.monitoring_finished.emit()


### PR DESCRIPTION
## Summary
- wake up the monitoring worker's action_complete event whenever monitoring is stopped
- prevent the scheduler from waiting on unfinished volume or camera monitors after manual aborts

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_6909698e8e608320b3ce2538a65a5caa