### PR TITLE
Support multi-device monitoring for display and camera

### DIFF
--- a/monitoring/actions/camera_monitor.py
+++ b/monitoring/actions/camera_monitor.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
+MAX_MONITORED_DEVICES = 3
+
+
 def run(
     context: "Patvs_Fuction",
     target_cycles: float,
@@ -40,8 +43,8 @@ def run(
     remaining = max(0.0, min(total_target, remaining))
 
     cycle_count = max(0.0, total_target - remaining)
-    last_camera_state = None
-    cycle_started = False
+    device_states: list[bool | None] = [None] * MAX_MONITORED_DEVICES
+    cycles_started = [False] * MAX_MONITORED_DEVICES
     expected_keys = {"摄像头", "camera"}
 
     if cycle_count > 0:
@@ -50,24 +53,45 @@ def run(
         )
 
     while context.is_running and cycle_count < total_target:
-        cap = cv2.VideoCapture(0)
-        ret, _ = cap.read()
-        cap.release()
-        current_camera_state = ret
+        for device_index in range(MAX_MONITORED_DEVICES):
+            cap = cv2.VideoCapture(device_index)
+            try:
+                if cap.isOpened():
+                    ret, _ = cap.read()
+                else:
+                    ret = False
+            except Exception:
+                ret = False
+            finally:
+                cap.release()
 
-        if last_camera_state is not None:
-            if not cycle_started and last_camera_state and not current_camera_state:
-                cycle_started = True
-                context.log("检测到摄像头被占用，开关周期开始。")
-            elif cycle_started and not last_camera_state and current_camera_state:
+            current_state = bool(ret)
+            previous_state = device_states[device_index]
+            device_states[device_index] = current_state
+
+            if previous_state is None:
+                continue
+
+            if not cycles_started[device_index] and previous_state and not current_state:
+                cycles_started[device_index] = True
+                context.log(f"检测到摄像头 {device_index} 被占用，开关周期开始。")
+            elif (
+                cycles_started[device_index]
+                and not previous_state
+                and current_state
+            ):
                 cycle_count += 1
-                cycle_started = False
-                context.log(f"检测到摄像头可以调用，完成一个开关周期！当前周期数：{cycle_count}")
+                cycles_started[device_index] = False
+                context.log(
+                    f"检测到摄像头 {device_index} 可以调用，完成一个开关周期！当前周期数：{cycle_count}"
+                )
                 context.record_count_progress_if_current(
                     total_target, cycle_count, expected_keys=expected_keys
                 )
 
-        last_camera_state = current_camera_state
+            if cycle_count >= total_target:
+                break
+
         if cycle_count >= total_target:
             context.log(f"摄像头开关周期数已达到目标值 ({total_target})，退出检测。")
             break

--- a/monitoring/actions/display_monitor.py
+++ b/monitoring/actions/display_monitor.py
@@ -10,6 +10,9 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
+MAX_MONITORED_DEVICES = 3
+
+
 def run(
     context: "Patvs_Fuction",
     target_cycles: float,
@@ -35,9 +38,8 @@ def run(
             remaining = total_target
     remaining = max(0.0, min(total_target, remaining))
 
-    previous_brightness = None
     off_cycle_count = max(0.0, total_target - remaining)
-    was_display_on = True
+    device_states: list[bool | None] = [None] * MAX_MONITORED_DEVICES
     expected_keys = {"显示器"}
 
     if off_cycle_count > 0:
@@ -46,26 +48,39 @@ def run(
         )
 
     while context.is_running and off_cycle_count < total_target:
-        try:
-            current_brightness = sbc.get_brightness(display=0)
-            context.log(f"当前显示器亮度: {current_brightness}")
-            if current_brightness == 0:
-                raise RuntimeError("Brightness is 0, assuming display is off.")
+        cycle_incremented = False
+        for device_index in range(MAX_MONITORED_DEVICES):
+            try:
+                brightness = sbc.get_brightness(display=device_index)
+                if isinstance(brightness, list):
+                    brightness = brightness[0] if brightness else 0
+                context.log(f"显示器 {device_index} 当前亮度: {brightness}")
+                current_state = bool(brightness)
+            except Exception as exc:
+                context.log(f"检测到显示器 {device_index} 已关闭: {exc}")
+                current_state = False
 
-            if previous_brightness is None:
-                previous_brightness = current_brightness
+            previous_state = device_states[device_index]
+            device_states[device_index] = current_state
 
-            was_display_on = True
-        except Exception as exc:
-            context.log(f"检测到屏幕已关闭: {exc}")
-            if was_display_on and previous_brightness:
+            if previous_state is None or cycle_incremented:
+                continue
+
+            if previous_state and not current_state:
                 off_cycle_count += 1
-                context.log(f"显示器关闭周期完成: {off_cycle_count} 次")
+                cycle_incremented = True
+                context.log(
+                    f"显示器 {device_index} 关闭周期完成: {off_cycle_count} 次"
+                )
                 context.record_count_progress_if_current(
                     total_target, off_cycle_count, expected_keys=expected_keys
                 )
-            was_display_on = False
-            previous_brightness = None
+
+            if off_cycle_count >= total_target:
+                break
+
+        if off_cycle_count >= total_target:
+            break
 
         time.sleep(5)
 


### PR DESCRIPTION
## Summary
- extend the display monitor to scan the first three displays and count a cycle when any of them turn off
- update the camera monitor to watch the first three capture devices and record a cycle when any device toggles availability

## Testing
- python -m compileall monitoring/actions/camera_monitor.py monitoring/actions/display_monitor.py

------
https://chatgpt.com/codex/tasks/task_b_6909af6a9b188320a6e2ac1ee34b4f54