### PR TITLE
Fix S3 power cycle monitoring concurrency and graceful stop

### DIFF
--- a/monitoring/actions/s3_power_cycle_monitor.py
+++ b/monitoring/actions/s3_power_cycle_monitor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from typing import TYPE_CHECKING
 
 from . import power_plug_monitor, s3_sleep_monitor
@@ -10,18 +11,28 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..patvs_monitor import Patvs_Fuction
 
 
+def _sanitize_progress(value, fallback=0.0):
+    try:
+        return max(0.0, float(value))
+    except (TypeError, ValueError):
+        return fallback
+
+
 def run(
     context: "Patvs_Fuction",
     start_time,
     target_cycles,
     remaining_cycles: float | None = None,
+    *,
+    s3_progress: float | None = None,
+    power_progress: float | None = None,
 ) -> None:
-    """顺序执行 S3 睡眠与电源插拔动作，支持断点续跑。"""
+    """并行监控 S3 睡眠与电源插拔动作，支持断点续跑。"""
 
     try:
-        total_target = int(float(target_cycles))
+        total_target = float(target_cycles)
     except (TypeError, ValueError):
-        total_target = 0
+        total_target = 0.0
 
     if total_target <= 0:
         context.log("S3 电源插拔目标次数为 0，自动跳过。")
@@ -29,41 +40,95 @@ def run(
         return
 
     if remaining_cycles is None:
-        remaining = float(total_target)
+        remaining = total_target
     else:
         try:
             remaining = float(remaining_cycles)
         except (TypeError, ValueError):
-            remaining = float(total_target)
-    remaining = max(0.0, min(float(total_target), remaining))
-    completed = int(max(0.0, float(total_target) - remaining))
+            remaining = total_target
+    remaining = max(0.0, min(total_target, remaining))
 
-    context.log(f"开始执行监控: S3电源插拔，目标测试次数: {total_target}")
-    if completed > 0:
+    combined_completed = max(0.0, total_target - remaining)
+    s3_completed = _sanitize_progress(s3_progress, combined_completed)
+    power_completed = _sanitize_progress(power_progress, combined_completed)
+    combined_completed = min(total_target, s3_completed, power_completed)
+
+    context._record_s3_power_progress(
+        total_target, s3_completed=s3_completed, power_completed=power_completed
+    )
+
+    context.log(f"开始执行监控: S3电源插拔，目标测试次数: {int(total_target)}")
+    if combined_completed >= total_target:
+        context.log("所有插拔+S3循环已完成！")
+        context.action_complete.set()
+        return
+    if combined_completed > 0:
         context.log(
-            f"S3 电源插拔已累计完成 {completed} 次，剩余 {max(0, total_target - completed)} 次。"
+            "S3 电源插拔已累计完成 "
+            f"{combined_completed:g} 次，剩余 {max(0.0, total_target - combined_completed):g} 次。"
         )
 
-    for index in range(completed, total_target):
-        s3_done_event = threading.Event()
-        s3_thread = threading.Thread(
-            target=s3_sleep_monitor.run,
-            args=(context, start_time, index + 1, s3_done_event),
-        )
-        s3_thread.start()
-        s3_done_event.wait()
-        s3_thread.join()
+    power_remaining = max(0.0, total_target - power_completed)
+    power_event = threading.Event()
+    power_thread = threading.Thread(
+        target=power_plug_monitor.run,
+        args=(context, total_target, power_event),
+        kwargs={"remaining_cycles": power_remaining},
+    )
 
-        power_done_event = threading.Event()
-        power_thread = threading.Thread(
-            target=power_plug_monitor.run,
-            args=(context, 1, power_done_event),
-        )
-        power_thread.start()
-        power_done_event.wait()
-        power_thread.join()
+    s3_event = threading.Event()
+    s3_thread = threading.Thread(
+        target=s3_sleep_monitor.run,
+        args=(context, start_time, total_target, s3_event),
+    )
 
-        context.log(f"已完成第{index + 1}轮插拔+S3")
+    s3_thread.start()
+    power_thread.start()
 
-    context.log("所有插拔+S3循环已完成！")
+    last_logged = combined_completed
+
+    while context.is_running:
+        with context.state_lock:
+            if not context.remaining_actions:
+                break
+            current = context.remaining_actions[0]
+            if context.normalize_action(current.get("name", "")) != "s3电源插拔":
+                break
+            s3_completed = _sanitize_progress(current.get("s3_progress", s3_completed), s3_completed)
+            power_completed = _sanitize_progress(
+                current.get("power_progress", power_completed), power_completed
+            )
+        combined = min(total_target, s3_completed, power_completed)
+        if combined > last_logged:
+            context.log(f"已完成第{int(combined)}轮插拔+S3")
+            last_logged = combined
+        if combined >= total_target:
+            break
+        if s3_event.is_set() and power_event.is_set():
+            break
+        time.sleep(0.5)
+
+    s3_thread.join()
+    power_thread.join()
+
+    with context.state_lock:
+        if context.remaining_actions and context.normalize_action(
+            context.remaining_actions[0].get("name", "")
+        ) == "s3电源插拔":
+            s3_completed = _sanitize_progress(
+                context.remaining_actions[0].get("s3_progress", s3_completed), s3_completed
+            )
+            power_completed = _sanitize_progress(
+                context.remaining_actions[0].get("power_progress", power_completed),
+                power_completed,
+            )
+            combined_final = min(total_target, s3_completed, power_completed)
+        else:
+            combined_final = min(total_target, last_logged)
+
+    if combined_final >= total_target:
+        context.log("所有插拔+S3循环已完成！")
+    else:
+        context.log("S3 电源插拔监控已终止。")
+
     context.action_complete.set()

--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -204,6 +204,9 @@ class Patvs_Fuction:
                     "remaining": float(max(0.0, numeric_amount)),
                 }
             )
+        if self.normalize_action(str(action)) == "s3电源插拔":
+            normalized.setdefault("s3_progress", 0.0)
+            normalized.setdefault("power_progress", 0.0)
         return normalized
 
     def _normalize_stored_action(self, action):
@@ -228,6 +231,17 @@ class Patvs_Fuction:
                 "target": max(0.0, target),
                 "remaining": max(0.0, remaining),
             }
+            if self.normalize_action(name) == "s3电源插拔":
+                try:
+                    s3_progress = float(action.get("s3_progress", 0.0))
+                except (TypeError, ValueError):
+                    s3_progress = 0.0
+                try:
+                    power_progress = float(action.get("power_progress", 0.0))
+                except (TypeError, ValueError):
+                    power_progress = 0.0
+                normalized["s3_progress"] = max(0.0, s3_progress)
+                normalized["power_progress"] = max(0.0, power_progress)
             name_key = str(name).strip().lower()
             if (
                 normalized["unit"] == "seconds"
@@ -265,20 +279,83 @@ class Patvs_Fuction:
         return removed
 
     def _record_count_progress(self, target, completed, action_key=None):
-        if action_key is not None:
-            with self.state_lock:
-                current_name = (
-                    self.remaining_actions[0]["name"]
-                    if self.remaining_actions
-                    else None
-                )
-            if current_name is None or self.normalize_action(current_name) != action_key:
+        normalized_action_key = (
+            self.normalize_action(action_key) if action_key is not None else None
+        )
+        with self.state_lock:
+            current_name = (
+                self.remaining_actions[0]["name"]
+                if self.remaining_actions
+                else None
+            )
+        if current_name is None:
+            return
+        normalized_current = self.normalize_action(current_name)
+        if normalized_current == "s3电源插拔":
+            if normalized_action_key == "s3":
+                self._record_s3_power_progress(target, s3_completed=completed)
                 return
+            if normalized_action_key in {None, "电源插拔"}:
+                self._record_s3_power_progress(target, power_completed=completed)
+                return
+        if (
+            action_key is not None
+            and normalized_action_key is not None
+            and normalized_current != normalized_action_key
+        ):
+            return
         try:
             remaining = float(target) - float(completed)
         except (TypeError, ValueError):
             remaining = 0.0
         self._update_current_action_remaining(max(0.0, remaining))
+
+    def _record_s3_power_progress(
+        self,
+        target,
+        *,
+        s3_completed: float | None = None,
+        power_completed: float | None = None,
+    ) -> None:
+        updated = False
+        with self.state_lock:
+            if not self.remaining_actions:
+                return
+            current = self.remaining_actions[0]
+            if self.normalize_action(current.get("name", "")) != "s3电源插拔":
+                return
+            try:
+                target_total = float(target)
+            except (TypeError, ValueError):
+                target_total = float(current.get("target", 0.0) or 0.0)
+            target_total = max(0.0, target_total)
+
+            def _clamp(value, default=0.0):
+                try:
+                    return max(0.0, float(value))
+                except (TypeError, ValueError):
+                    return default
+
+            if s3_completed is not None:
+                new_s3 = _clamp(s3_completed)
+                if new_s3 != _clamp(current.get("s3_progress", 0.0)):
+                    current["s3_progress"] = new_s3
+                    updated = True
+            if power_completed is not None:
+                new_power = _clamp(power_completed)
+                if new_power != _clamp(current.get("power_progress", 0.0)):
+                    current["power_progress"] = new_power
+                    updated = True
+
+            s3_value = _clamp(current.get("s3_progress", 0.0))
+            power_value = _clamp(current.get("power_progress", 0.0))
+            combined = min(target_total, s3_value, power_value)
+            remaining = max(0.0, target_total - combined)
+            if remaining != _clamp(current.get("remaining", target_total), target_total):
+                current["remaining"] = remaining
+                updated = True
+        if updated:
+            self.save_session_state()
 
     def record_count_progress_if_current(self, target, completed, expected_keys=None):
         """更新当前动作的次数进度，避免串扰其他动作。"""
@@ -718,7 +795,11 @@ class Patvs_Fuction:
                         threading.Thread(
                             target=s3_power_cycle_monitor.run,
                             args=(self, self.case_start_time, target_value),
-                            kwargs={"remaining_cycles": remaining_value_float},
+                            kwargs={
+                                "remaining_cycles": remaining_value_float,
+                                "s3_progress": current_action.get("s3_progress"),
+                                "power_progress": current_action.get("power_progress"),
+                            },
                         ).start()
                     elif normalized_action == "显示器":
                         self.log(


### PR DESCRIPTION
## Summary
- run the S3 sleep and power plug monitors concurrently for the combined action so each counter advances independently
- persist partial S3 and power progress to resume accurately and honour early termination requests

## Testing
- python -m compileall monitoring

------
https://chatgpt.com/codex/tasks/task_b_6909c16adffc83208f68e2f01f0c476f