### PR TITLE
Ensure USB and lock screen monitors stop cleanly on manual failure

### DIFF
--- a/monitoring/manager.py
+++ b/monitoring/manager.py
@@ -1,13 +1,26 @@
 """Qt friendly wrapper around the legacy monitoring implementation."""
 from __future__ import annotations
 
+import logging
 import threading
+from importlib import import_module, util as importlib_util
 from typing import Sequence, Tuple
 
 from PyQt5 import QtCore
 
 from .patvs_monitor import Patvs_Fuction
 from .parser import MonitoringAction
+
+
+logger = logging.getLogger(__name__)
+
+_WIN32API_SPEC = importlib_util.find_spec("win32api")
+if _WIN32API_SPEC is not None:
+    win32api = import_module("win32api")
+else:  # pragma: no cover - platform dependent
+    win32api = None
+
+WM_QUIT = 0x0012
 
 
 class MonitoringManager(QtCore.QObject):
@@ -21,17 +34,20 @@ class MonitoringManager(QtCore.QObject):
         super().__init__()
         self._worker: Patvs_Fuction | None = None
         self._thread: threading.Thread | None = None
+        self._active_actions: Tuple[str, ...] = ()
 
     # ------------------------------------------------------------------
     def is_running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
-    def stop(self) -> None:
+    def stop(self, *, force_message_loop_stop: bool = False) -> None:
         if self._worker is None:
             return
         self._worker.is_running = False
         # 立即唤醒可能正在等待动作完成的主调度线程，避免阻塞
         self._worker.action_complete.set()
+        if force_message_loop_stop and self._requires_message_loop_stop():
+            self._request_message_loop_exit()
 
     def discard_session_state(self) -> None:
         """Clear any persisted monitoring progress for the active worker."""
@@ -48,6 +64,7 @@ class MonitoringManager(QtCore.QObject):
             return
 
         legacy_actions: Tuple[Tuple[str, float], ...] = tuple((a.name, a.amount) for a in actions)
+        self._active_actions = tuple(name.strip().lower() for name, _ in legacy_actions)
 
         adapter = _WindowAdapter(self)
         self._worker = Patvs_Fuction(window=adapter, is_running=True)
@@ -69,12 +86,43 @@ class MonitoringManager(QtCore.QObject):
         thread = self._thread
         self._worker = None
         self._thread = None
+        self._active_actions = ()
         if worker:
             worker.is_running = False
             worker.action_complete.set()
         if thread and thread is not threading.current_thread():
             thread.join(timeout=0)
         self.monitoring_finished.emit()
+
+    # ------------------------------------------------------------------
+    def _requires_message_loop_stop(self) -> bool:
+        for name in self._active_actions:
+            if "usb插拔" in name or "锁屏" in name:
+                return True
+        return False
+
+    def _request_message_loop_exit(self) -> None:
+        worker = self._worker
+        if worker is None:
+            return
+        thread_id = worker.msg_loop_thread_id
+        if not thread_id:
+            return
+        if win32api is None:  # pragma: no cover - platform dependent
+            logger.debug(
+                "win32api 不可用，无法向监控消息循环线程 %s 发送 WM_QUIT", thread_id
+            )
+            return
+        try:
+            win32api.PostThreadMessage(int(thread_id), WM_QUIT, 0, 0)
+        except Exception as exc:  # pragma: no cover - hardware interaction
+            logger.warning(
+                "向监控消息循环线程 %s 发送 WM_QUIT 失败: %s", thread_id, exc
+            )
+        else:
+            logger.debug("已向监控消息循环线程 %s 发送 WM_QUIT", thread_id)
+        finally:
+            worker.msg_loop_thread_id = None
 
 
 class _WindowAdapter:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1736,6 +1736,15 @@ class MainWindow(QtWidgets.QMainWindow):
                 hint_text = f"{entry.device_label}"
         return device_model_id, plan_device_model_id, hint_text
 
+    def _actions_require_message_loop_stop(
+        self, actions: Sequence[MonitoringAction]
+    ) -> bool:
+        for action in actions:
+            normalized = action.name.strip().lower()
+            if "usb插拔" in normalized or "锁屏" in normalized:
+                return True
+        return False
+
     def _submit_result(self, result: str) -> None:
         if not self._current_case:
             QtWidgets.QMessageBox.warning(self, "未选择", "请先选择用例")
@@ -1780,8 +1789,9 @@ class MainWindow(QtWidgets.QMainWindow):
             {k: v for k, v in payload.items() if k != "local_path"}
             for payload in dialog.attachments()
         ]
+        force_stop = result in {"fail", "blocked"} and self._actions_require_message_loop_stop(actions)
         if self._monitoring.is_running():
-            self._monitoring.stop()
+            self._monitoring.stop(force_message_loop_stop=force_stop)
             self._append_log("监控停止请求已发送")
         self._monitoring.discard_session_state()
         self._awaiting_monitor_completion_for_pass = False


### PR DESCRIPTION
## Summary
- post a WM_QUIT to USB and lock screen monitoring message loops when forcing a stop
- flag fail and blocked submissions that require the forced stop in the main window logic

## Testing
- python -m compileall ui/main_window.py monitoring/manager.py

------
https://chatgpt.com/codex/tasks/task_b_690b11fed7fc8320a590d81fa70a6007