### PR TITLE
Ensure USB and lock monitors exit when forced to stop

### DIFF
--- a/monitoring/actions/s3_usb_cycle_monitor.py
+++ b/monitoring/actions/s3_usb_cycle_monitor.py
@@ -61,4 +61,6 @@ def run(
     context.action_complete.set()
     s3_thread.join()
     usb_thread.join()
+    if context.msg_loop_thread_id == usb_thread.ident:
+        context.msg_loop_thread_id = None
     context.log("S3 和 USB 插拔监控已完成。")

--- a/monitoring/actions/usb_monitor.py
+++ b/monitoring/actions/usb_monitor.py
@@ -47,9 +47,13 @@ def run(
         )
 
     notification = Notification(context, completed, total_target)
+    context.register_message_loop_shutdown(notification.stop)
     try:
         notification.messageLoop()
     finally:
+        context.register_message_loop_shutdown(None)
+        if context.msg_loop_thread_id == threading.get_ident():
+            context.msg_loop_thread_id = None
         context.log("停止 USB 插拔事件监控.")
         if usb_done_event:
             usb_done_event.set()

--- a/monitoring/devicerm.py
+++ b/monitoring/devicerm.py
@@ -77,6 +77,30 @@ class Notification:
             win32con.DEVICE_NOTIFY_WINDOW_HANDLE
         )
 
+    def stop(self):
+        if not self.hwnd:
+            return
+        try:
+            win32gui.PostMessage(self.hwnd, win32con.WM_CLOSE, 0, 0)
+        except pywintypes.error as exc:  # pragma: no cover - platform interaction
+            logger.warning("停止 USB 监控窗口失败: %s", exc)
+        except Exception as exc:  # pragma: no cover - platform interaction
+            logger.warning("停止 USB 监控窗口时出现未知异常: %s", exc)
+        thread_id = getattr(self.context, "msg_loop_thread_id", None)
+        if thread_id:
+            try:
+                win32api.PostThreadMessage(int(thread_id), win32con.WM_QUIT, 0, 0)
+            except pywintypes.error as exc:  # pragma: no cover - platform interaction
+                logger.warning(
+                    "向 USB 监控线程 %s 发送 WM_QUIT 失败: %s", thread_id, exc
+                )
+            except Exception as exc:  # pragma: no cover - platform interaction
+                logger.warning(
+                    "向 USB 监控线程 %s 发送 WM_QUIT 时出现未知异常: %s",
+                    thread_id,
+                    exc,
+                )
+
     def onDeviceChange(self, hwnd, message, wparam, lparam):
         dbch = win32gui_struct.UnpackDEV_BROADCAST(lparam)
         if wparam == win32con.DBT_DEVICEREMOVECOMPLETE:

--- a/monitoring/lock_screen.py
+++ b/monitoring/lock_screen.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 # 检测电脑锁屏事件
 import ctypes
+import logging
+import threading
+import uuid
+from typing import TYPE_CHECKING
+
+import pywintypes
 import win32api
 import win32con
 import win32gui
 import win32ts
-import uuid
 from PyQt5 import QtCore
-import logging
-from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +61,31 @@ class SessionNotificationHandler:
                                           0, 0, 0, 0,
                                           0, 0, 0, None)
         win32ts.WTSRegisterSessionNotification(self.hwnd, win32ts.NOTIFY_FOR_THIS_SESSION)
+
+    def stop(self):
+        if self.hwnd:
+            try:
+                win32ts.WTSUnRegisterSessionNotification(self.hwnd)
+            except Exception as exc:  # pragma: no cover - platform interaction
+                logger.warning("注销锁屏会话通知失败: %s", exc)
+            try:
+                win32gui.PostMessage(self.hwnd, win32con.WM_CLOSE, 0, 0)
+            except Exception as exc:  # pragma: no cover - platform interaction
+                logger.warning("关闭锁屏监控窗口失败: %s", exc)
+            thread_id = getattr(self.context, "msg_loop_thread_id", None)
+            if thread_id:
+                try:
+                    win32api.PostThreadMessage(int(thread_id), win32con.WM_QUIT, 0, 0)
+                except pywintypes.error as exc:  # pragma: no cover - platform interaction
+                    logger.warning(
+                        "向锁屏监控线程 %s 发送 WM_QUIT 失败: %s", thread_id, exc
+                    )
+                except Exception as exc:  # pragma: no cover - platform interaction
+                    logger.warning(
+                        "向锁屏监控线程 %s 发送 WM_QUIT 时出现未知异常: %s",
+                        thread_id,
+                        exc,
+                    )
 
     def wnd_proc(self, hwnd, msg, wparam, lparam):
         if msg == WM_WTSSESSION_CHANGE:  # 使用自定义的常量
@@ -123,4 +151,10 @@ def monitor_locks(context: "Patvs_Fuction", target_cycles, remaining_cycles=None
         )
 
     handler = SessionNotificationHandler(context, total_target, initial_count=completed)
-    handler.run()
+    context.register_message_loop_shutdown(handler.stop)
+    try:
+        handler.run()
+    finally:
+        context.register_message_loop_shutdown(None)
+        if context.msg_loop_thread_id == threading.get_ident():
+            context.msg_loop_thread_id = None

--- a/monitoring/manager.py
+++ b/monitoring/manager.py
@@ -1,13 +1,26 @@
 """Qt friendly wrapper around the legacy monitoring implementation."""
 from __future__ import annotations
 
+import logging
 import threading
+from importlib import import_module, util as importlib_util
 from typing import Sequence, Tuple
 
 from PyQt5 import QtCore
 
 from .patvs_monitor import Patvs_Fuction
 from .parser import MonitoringAction
+
+
+logger = logging.getLogger(__name__)
+
+_WIN32API_SPEC = importlib_util.find_spec("win32api")
+if _WIN32API_SPEC is not None:
+    win32api = import_module("win32api")
+else:  # pragma: no cover - platform dependent
+    win32api = None
+
+WM_QUIT = 0x0012
 
 
 class MonitoringManager(QtCore.QObject):
@@ -21,17 +34,20 @@ class MonitoringManager(QtCore.QObject):
         super().__init__()
         self._worker: Patvs_Fuction | None = None
         self._thread: threading.Thread | None = None
+        self._active_actions: Tuple[str, ...] = ()
 
     # ------------------------------------------------------------------
     def is_running(self) -> bool:
         return self._thread is not None and self._thread.is_alive()
 
-    def stop(self) -> None:
+    def stop(self, *, force_message_loop_stop: bool = False) -> None:
         if self._worker is None:
             return
         self._worker.is_running = False
         # 立即唤醒可能正在等待动作完成的主调度线程，避免阻塞
         self._worker.action_complete.set()
+        if force_message_loop_stop and self._requires_message_loop_stop():
+            self._request_message_loop_exit()
 
     def discard_session_state(self) -> None:
         """Clear any persisted monitoring progress for the active worker."""
@@ -48,6 +64,7 @@ class MonitoringManager(QtCore.QObject):
             return
 
         legacy_actions: Tuple[Tuple[str, float], ...] = tuple((a.name, a.amount) for a in actions)
+        self._active_actions = tuple(name.strip().lower() for name, _ in legacy_actions)
 
         adapter = _WindowAdapter(self)
         self._worker = Patvs_Fuction(window=adapter, is_running=True)
@@ -69,12 +86,56 @@ class MonitoringManager(QtCore.QObject):
         thread = self._thread
         self._worker = None
         self._thread = None
+        self._active_actions = ()
         if worker:
             worker.is_running = False
             worker.action_complete.set()
         if thread and thread is not threading.current_thread():
             thread.join(timeout=0)
         self.monitoring_finished.emit()
+
+    # ------------------------------------------------------------------
+    def _requires_message_loop_stop(self) -> bool:
+        for name in self._active_actions:
+            if "usb插拔" in name or "锁屏" in name:
+                return True
+        return False
+
+    def _request_message_loop_exit(self) -> None:
+        worker = self._worker
+        if worker is None:
+            return
+
+        callback_executed = worker.request_message_loop_shutdown()
+        if callback_executed:
+            logger.debug("已调用监控上下文注册的消息循环终止回调")
+
+        thread_id = worker.msg_loop_thread_id
+        if not thread_id:
+            if callback_executed:
+                logger.debug("消息循环线程已清除，不再发送 WM_QUIT")
+            return
+
+        if win32api is None:  # pragma: no cover - platform dependent
+            logger.debug(
+                "win32api 不可用，无法向监控消息循环线程 %s 发送 WM_QUIT", thread_id
+            )
+            return
+
+        try:
+            win32api.PostThreadMessage(int(thread_id), WM_QUIT, 0, 0)
+        except Exception as exc:  # pragma: no cover - hardware interaction
+            logger.warning(
+                "向监控消息循环线程 %s 发送 WM_QUIT 失败: %s", thread_id, exc
+            )
+        else:
+            logger.debug(
+                "已向监控消息循环线程 %s 发送 WM_QUIT (callback_executed=%s)",
+                thread_id,
+                callback_executed,
+            )
+        finally:
+            worker.msg_loop_thread_id = None
 
 
 class _WindowAdapter:

--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -160,12 +160,38 @@ class Patvs_Fuction:
         self.case_id: str | None = None
         self.action_complete = threading.Event()
         self.msg_loop_thread_id: int | None = None
+        self._message_loop_shutdown_lock = threading.Lock()
+        self._message_loop_shutdown: Callable[[], None] | None = None
         self.audio_log_files: list[str] = []
         self.audio_log_offsets: dict[str, int] = {}
         self.audio_event_cache: dict[str, int] = {}
         self.case_start_time: str | None = None
         self.state_lock = threading.Lock()
         self.session_reset_requested = False
+
+    # ------------------------------------------------------------------
+    def register_message_loop_shutdown(self, callback: Callable[[], None] | None) -> None:
+        """记录可用于终止当前消息循环的回调。"""
+
+        with self._message_loop_shutdown_lock:
+            self._message_loop_shutdown = callback
+
+    def request_message_loop_shutdown(self) -> bool:
+        """尝试执行已注册的消息循环终止回调。"""
+
+        with self._message_loop_shutdown_lock:
+            callback = self._message_loop_shutdown
+            self._message_loop_shutdown = None
+
+        if callback is None:
+            return False
+
+        try:
+            callback()
+        except Exception as exc:  # pragma: no cover - hardware interaction
+            self.logger.warning("终止监控消息循环时出现异常: %s", exc)
+            return False
+        return True
 
     # ------------------------------------------------------------------
     def log(self, message: str) -> None:

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1736,6 +1736,15 @@ class MainWindow(QtWidgets.QMainWindow):
                 hint_text = f"{entry.device_label}"
         return device_model_id, plan_device_model_id, hint_text
 
+    def _actions_require_message_loop_stop(
+        self, actions: Sequence[MonitoringAction]
+    ) -> bool:
+        for action in actions:
+            normalized = action.name.strip().lower()
+            if "usb插拔" in normalized or "锁屏" in normalized:
+                return True
+        return False
+
     def _submit_result(self, result: str) -> None:
         if not self._current_case:
             QtWidgets.QMessageBox.warning(self, "未选择", "请先选择用例")
@@ -1780,8 +1789,9 @@ class MainWindow(QtWidgets.QMainWindow):
             {k: v for k, v in payload.items() if k != "local_path"}
             for payload in dialog.attachments()
         ]
+        force_stop = result in {"fail", "blocked"} and self._actions_require_message_loop_stop(actions)
         if self._monitoring.is_running():
-            self._monitoring.stop()
+            self._monitoring.stop(force_message_loop_stop=force_stop)
             self._append_log("监控停止请求已发送")
         self._monitoring.discard_session_state()
         self._awaiting_monitor_completion_for_pass = False


### PR DESCRIPTION
## Summary
- always send WM_QUIT to message loop threads even after executing shutdown callbacks
- let USB and lock screen monitors post WM_QUIT themselves and clear stored thread ids when their loops exit
- reset the stored USB message loop thread id once the S3+USB combined monitor finishes

## Testing
- python -m compileall monitoring/manager.py monitoring/devicerm.py monitoring/actions/usb_monitor.py monitoring/lock_screen.py monitoring/actions/s3_usb_cycle_monitor.py

------
https://chatgpt.com/codex/tasks/task_b_690b11fed7fc8320a590d81fa70a6007