### PR TITLE
Fix manual abort leaving USB/lock screen message loops running

### DIFF
--- a/monitoring/actions/s3_usb_cycle_monitor.py
+++ b/monitoring/actions/s3_usb_cycle_monitor.py
@@ -53,7 +53,7 @@ def run(
 
     s3_thread.start()
     usb_thread.start()
-    context.msg_loop_thread_id = usb_thread.ident
+    context.register_message_loop_thread(usb_thread.ident)
 
     while not (s3_done_event.is_set() and usb_done_event.is_set()):
         time.sleep(0.5)

--- a/monitoring/actions/usb_monitor.py
+++ b/monitoring/actions/usb_monitor.py
@@ -50,6 +50,7 @@ def run(
     try:
         notification.messageLoop()
     finally:
+        context.clear_message_loop_thread(threading.get_ident())
         context.log("停止 USB 插拔事件监控.")
         if usb_done_event:
             usb_done_event.set()

--- a/monitoring/controller.py
+++ b/monitoring/controller.py
@@ -52,6 +52,7 @@ class MonitoringController(QtCore.QObject):
         if self._worker is None:
             return
         self._worker.is_running = False
+        self._worker.stop_message_loop()
         # 确保当前等待的动作线程被唤醒，避免主调度卡在 action_complete.wait()
         self._worker.action_complete.set()
 
@@ -88,4 +89,5 @@ class MonitoringController(QtCore.QObject):
             thread.join(timeout=0)
         if worker:
             worker.is_running = False
+            worker.stop_message_loop()
             worker.action_complete.set()

--- a/monitoring/lock_screen.py
+++ b/monitoring/lock_screen.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # 检测电脑锁屏事件
 import ctypes
+import threading
 import win32api
 import win32con
 import win32gui
@@ -123,4 +124,8 @@ def monitor_locks(context: "Patvs_Fuction", target_cycles, remaining_cycles=None
         )
 
     handler = SessionNotificationHandler(context, total_target, initial_count=completed)
-    handler.run()
+    current_thread = threading.get_ident()
+    try:
+        handler.run()
+    finally:
+        context.clear_message_loop_thread(current_thread)

--- a/monitoring/manager.py
+++ b/monitoring/manager.py
@@ -30,6 +30,7 @@ class MonitoringManager(QtCore.QObject):
         if self._worker is None:
             return
         self._worker.is_running = False
+        self._worker.stop_message_loop()
         # 立即唤醒可能正在等待动作完成的主调度线程，避免阻塞
         self._worker.action_complete.set()
 
@@ -71,6 +72,7 @@ class MonitoringManager(QtCore.QObject):
         self._thread = None
         if worker:
             worker.is_running = False
+            worker.stop_message_loop()
             worker.action_complete.set()
         if thread and thread is not threading.current_thread():
             thread.join(timeout=0)

--- a/monitoring/patvs_monitor.py
+++ b/monitoring/patvs_monitor.py
@@ -10,6 +10,9 @@ import time
 from pathlib import Path
 from typing import Callable
 
+import pywintypes
+import win32api
+import win32con
 import win32evtlog
 from cryptography.fernet import Fernet
 from pynput import keyboard
@@ -177,6 +180,34 @@ class Patvs_Fuction:
         """封装 wx.CallAfter，供动作内部复用。"""
 
         wx.CallAfter(func, *args, **kwargs)
+
+    # ------------------------------------------------------------------
+    def register_message_loop_thread(self, thread_id: int | None) -> None:
+        """记录当前使用消息循环的线程。"""
+
+        with self.state_lock:
+            self.msg_loop_thread_id = thread_id
+
+    def clear_message_loop_thread(self, thread_id: int | None = None) -> None:
+        """清理消息循环线程 ID，避免后续误用。"""
+
+        with self.state_lock:
+            if thread_id is None or self.msg_loop_thread_id == thread_id:
+                self.msg_loop_thread_id = None
+
+    def stop_message_loop(self) -> None:
+        """尝试停止当前活动的 Windows 消息循环。"""
+
+        with self.state_lock:
+            thread_id = self.msg_loop_thread_id
+        if not thread_id:
+            return
+        try:
+            win32api.PostThreadMessage(thread_id, win32con.WM_QUIT, 0, 0)
+        except pywintypes.error as exc:  # pragma: no cover - system level interaction
+            self.logger.warning("无法停止消息循环线程 %s: %s", thread_id, exc)
+        finally:
+            self.clear_message_loop_thread(thread_id)
 
     # ------------------------------------------------------------------
     def _build_action_state(self, action, amount):
@@ -703,7 +734,7 @@ class Patvs_Fuction:
                             kwargs={"remaining_cycles": remaining_value_float},
                         )
                         thread.start()
-                        self.msg_loop_thread_id = thread.ident
+                        self.register_message_loop_thread(thread.ident)
                     elif normalized_action == "键盘按键":
                         self.log(
                             f"开始执行监控: {action}，目标测试次数: {target_value:g}"
@@ -723,7 +754,7 @@ class Patvs_Fuction:
                             kwargs={"remaining_cycles": remaining_value_float},
                         )
                         thread.start()
-                        self.msg_loop_thread_id = thread.ident
+                        self.register_message_loop_thread(thread.ident)
                     elif normalized_action == "鼠标点击":
                         self.log(
                             f"开始执行监控: {action}，目标测试次数: {target_value:g}"


### PR DESCRIPTION
## Summary
- add message-loop tracking helpers to `Patvs_Fuction` and post `WM_QUIT` when aborting monitoring
- ensure USB and lock-screen monitors clear their registered message-loop threads as they exit
- update the monitoring controllers to invoke the new stop helper when a run is cancelled

## Testing
- not run (hardware-dependent Windows monitoring)


------
https://chatgpt.com/codex/tasks/task_b_690b1b4b86ac83209037bdd8c8a4a4a6